### PR TITLE
Show consistent predictions when alerts showing

### DIFF
--- a/ios/BioKernel/BioKernel/BioKernelApp.swift
+++ b/ios/BioKernel/BioKernel/BioKernelApp.swift
@@ -13,7 +13,6 @@ struct BioKernelApp: App {
     @UIApplicationDelegateAdaptor(MyAppDelegate.self) var appDelegate
     
     init() {
-        UIApplication.shared.statusBarStyle = .lightContent
         //G7CGMManager.debugLogger = getDebugLogger()
         getBackgroundService().registerBackgroundTask()
     }
@@ -26,6 +25,7 @@ struct BioKernelApp: App {
                 Text("Running tests")
             } else {
                 MainView()
+                    .toolbarColorScheme(.dark, for: .navigationBar)
             }
         }
     }

--- a/ios/BioKernel/BioKernel/Services/GlucoseAlertStorage.swift
+++ b/ios/BioKernel/BioKernel/Services/GlucoseAlertStorage.swift
@@ -108,7 +108,7 @@ class PredictiveGlucoseAlertStorage: GlucoseAlertStorage {
         let settings = (try? storage.read()) ?? GlucoseAlertSettings.defaults()
         glucoseAlertSettings = settings
         DispatchQueue.main.async {
-            self.alertViewModel.update(settings: settings)
+            self.alertViewModel.update(settings: settings, predictedGlucose: nil)
         }
     }
     func viewModel() -> GlucoseAlertsViewModel {
@@ -209,7 +209,7 @@ class PredictiveGlucoseAlertStorage: GlucoseAlertStorage {
         print("Predicted: \(predictedGlucose)")
         
         DispatchQueue.main.async {
-            self.alertViewModel.update(settings: newSettings)
+            self.alertViewModel.update(settings: newSettings, predictedGlucose: predictedGlucose)
         }
     }
     

--- a/ios/BioKernel/BioKernel/ViewModels/GlucoseAlertsViewModel.swift
+++ b/ios/BioKernel/BioKernel/ViewModels/GlucoseAlertsViewModel.swift
@@ -23,6 +23,7 @@ public class GlucoseAlertsViewModel: ObservableObject {
     @Published var lowLevel = GlucoseAlertValue(id: "70 mg/dl", value: 70)
     @Published var lowRepeats = never
     @Published var alertString: String? = nil
+    @Published var mostRecentPredictedGlucose: Double? = nil
     var alertStringFromSettings: String? = nil
     
     func glucoseAlertValue(from: Double) -> GlucoseAlertValue {
@@ -36,13 +37,14 @@ public class GlucoseAlertsViewModel: ObservableObject {
         }
         return GlucoseAlertValue(id: "\(value)m", value: value)
     }
-    func update(settings: GlucoseAlertSettings) {
+    func update(settings: GlucoseAlertSettings, predictedGlucose: Double?) {
         enabled = settings.enabled
         highLevel = glucoseAlertValue(from: settings.highLevelMgDl)
         highRepeats = repeatsValue(fromSeconds: settings.highRepeatsSeconds)
         lowLevel = glucoseAlertValue(from: settings.lowLevelMgDl)
         lowRepeats = repeatsValue(fromSeconds: settings.lowRepeatsSeconds)
         alertStringFromSettings = settings.alertString
+        mostRecentPredictedGlucose = predictedGlucose
         
         if settings.enabled {
             alertString = settings.alertString

--- a/ios/BioKernel/BioKernel/Views/MainViewSummaryView.swift
+++ b/ios/BioKernel/BioKernel/Views/MainViewSummaryView.swift
@@ -47,9 +47,7 @@ struct MainViewSummaryView: View {
                     }
                     if glucoseAlertsViewModel.alertString != nil {
                         if let predictedGlucose = glucoseAlertsViewModel.mostRecentPredictedGlucose {
-                            VStack {
-                                Text(String(format: "%0.0f", predictedGlucose.clamp(low: 40, high: 400))).font(.title)
-                            }
+                            Text(String(format: "%0.0f", predictedGlucose.clamp(low: 40, high: 400))).font(.title)
                         } else {
                             Text("-")
                         }

--- a/ios/BioKernel/BioKernel/Views/MainViewSummaryView.swift
+++ b/ios/BioKernel/BioKernel/Views/MainViewSummaryView.swift
@@ -46,9 +46,18 @@ struct MainViewSummaryView: View {
                         Text("-")
                     }
                     if glucoseAlertsViewModel.alertString != nil {
-                        Text("-")
+                        if let predictedGlucose = glucoseAlertsViewModel.mostRecentPredictedGlucose {
+                            VStack {
+                                Text(String(format: "%0.0f", predictedGlucose.clamp(low: 40, high: 400))).font(.title)
+                            }
+                        } else {
+                            Text("-")
+                        }
                     } else if let predictedGlucose = predictedGlucose {
-                        Text(String(format: "%0.0f", predictedGlucose.clamp(low: 40, high: 400))).font(.title)
+                        VStack {
+                            Text(String(format: "%0.0f", predictedGlucose.clamp(low: 40, high: 400))).font(.title)
+                            Text("In 15m")
+                        }
                     } else {
                         Text("-")
                     }


### PR DESCRIPTION
In general the predictions show realtime predictions 15 minutes in the future. But when we're showing an alert, we use the value from the alert to make sure that the two numbers are consistent.