### PR TITLE
Fix lock and add save prompt

### DIFF
--- a/ios/BioKernel/BioKernelWatch Watch App/StateViewModel.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/StateViewModel.swift
@@ -34,7 +34,8 @@ extension BioKernelState {
         return Int(Date().timeIntervalSince(lastUpdate).secondsToMinutes())
     }
     
-    func lastGlucose() -> Int? {
-        return self.glucoseReadings.last.map { Int($0.glucoseReadingInMgDl) }
+    func lastGlucoseString() -> String? {
+        guard let lastGlucose = self.glucoseReadings.last else { return nil }
+        return "\(String(format: "%0.0f", lastGlucose.glucoseReadingInMgDl))\(lastGlucose.trend ?? "")"
     }
 }

--- a/ios/BioKernel/BioKernelWatch Watch App/WatchMainView.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/WatchMainView.swift
@@ -37,6 +37,8 @@ struct WatchMainView: View {
                 ControlsView(stopWorkout: {
                     showingWorkout = false
                     normalModeSelection = 0
+                }, afterLock: {
+                    workoutModeSelection = 1
                 })
                     .tag(0)
                     .environmentObject(workoutManager)

--- a/ios/BioKernel/BioKernelWatch Watch App/Workout/ControlsView.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/Workout/ControlsView.swift
@@ -10,13 +10,16 @@ import SwiftUI
 
 struct ControlsView: View {
     let stopWorkout: () -> Void
+    let afterLock: () -> Void
+
     @EnvironmentObject var workoutManager: WorkoutManager
+    @State var showingEndWorkoutAlert = false
     
     var body: some View {
         VStack {
             HStack {
                 VStack {
-                    Button(action: { workoutManager.end(); stopWorkout() }) {
+                    Button(action: { showingEndWorkoutAlert = true }) {
                         Image(systemName: "xmark")
                     }
                     .tint(.red)
@@ -35,6 +38,7 @@ struct ControlsView: View {
             VStack {
                 Button {
                     workoutManager.lock()
+                    afterLock()
                 } label: {
                     Image(systemName: "lock")
                 }
@@ -43,12 +47,27 @@ struct ControlsView: View {
                 Text("Lock")
             }
         }
+        .confirmationDialog("End Workout?", isPresented: $showingEndWorkoutAlert, titleVisibility: .visible) {
+            Button("Save Workout", role: .none) {
+                workoutManager.end(save: true)
+                stopWorkout()
+            }
+            Button("Discard Workout", role: .destructive) {
+                workoutManager.end(save: false)
+                stopWorkout()
+            }
+            Button("Resume Workout", role: .cancel) {
+                // Do nothing, just dismiss
+            }
+        } message: {
+            
+        }
     }
 }
 
 struct ControlsView_Previews: PreviewProvider {
     static var previews: some View {
-        ControlsView(stopWorkout: {})
+        ControlsView(stopWorkout: {}, afterLock: {})
             .environmentObject(WorkoutManager())
     }
 }

--- a/ios/BioKernel/BioKernelWatch Watch App/Workout/MetricsView.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/Workout/MetricsView.swift
@@ -17,7 +17,11 @@ struct MetricsView: View {
             VStack(alignment: .leading) {
                 Text(workoutManager.builder?.elapsedTime.toHMS() ?? "-")
                 HStack {
-                    Text("\(stateViewModel.appState?.lastGlucose() ?? 0)").font(.largeTitle).fontWeight(.bold)
+                    Text("\(stateViewModel.appState?.lastGlucoseString() ?? "-")")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .minimumScaleFactor(0.3)
+                        .lineLimit(1)
                     VStack {
                         HStack {
                             Text("mg/dL")

--- a/ios/BioKernel/BioKernelWatch Watch App/Workout/WorkoutManager.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/Workout/WorkoutManager.swift
@@ -82,8 +82,13 @@ class WorkoutManager: NSObject, ObservableObject {
         }
     }
     
-    func end() {
-        session?.end()
+    func end(save: Bool) {
+        if save {
+            session?.end()
+        } else {
+            builder?.discardWorkout()
+            session?.end()
+        }
     }
     
     func lock() {


### PR DESCRIPTION
When locking the watch during exercise, transition the view back to the metrics view. Also, I added a prompt that let's people either save or discard a workout when they end it.