### PR TITLE
Exercise adaptations

### DIFF
--- a/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
+++ b/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
@@ -87,6 +87,8 @@
 		3BE6DDE02D0870840032DD7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B709A7E2AF492A0004E5885 /* Assets.xcassets */; };
 		3BE8ADA12B2A4DCE0002BB3E /* UserDefaults+Json.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE8ADA02B2A4DCE0002BB3E /* UserDefaults+Json.swift */; };
 		3BEE4E202B5FF4A000A09203 /* DateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BEE4E1F2B5FF4A000A09203 /* DateTime.swift */; };
+		3BF1631C2D20A6B700287BA0 /* WorkoutStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1631B2D20A6B700287BA0 /* WorkoutStatusService.swift */; };
+		3BF1631E2D20D69F00287BA0 /* WorkoutStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1631D2D20D69F00287BA0 /* WorkoutStatusView.swift */; };
 		3BF1BB262D0B1C2B00135F86 /* StoredJsonObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7553CD2AFD610B00FAD880 /* StoredJsonObject.swift */; };
 		3BF1BB272D0B1CA800135F86 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7553DD2AFDB2DA00FAD880 /* Debug.swift */; };
 		3BF1BB292D0B253000135F86 /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD793822AF564EA00E5FDC9 /* DateExtensions.swift */; };
@@ -270,6 +272,8 @@
 		3BE6DDCE2D08706D0032DD7F /* BioKernelWatch Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "BioKernelWatch Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BE8ADA02B2A4DCE0002BB3E /* UserDefaults+Json.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Json.swift"; sourceTree = "<group>"; };
 		3BEE4E1F2B5FF4A000A09203 /* DateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTime.swift; sourceTree = "<group>"; };
+		3BF1631B2D20A6B700287BA0 /* WorkoutStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutStatusService.swift; sourceTree = "<group>"; };
+		3BF1631D2D20D69F00287BA0 /* WorkoutStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutStatusView.swift; sourceTree = "<group>"; };
 		3C07C88E2AF9625A008F604C /* OmniBLE.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OmniBLE.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C07C8972AF964E4008F604C /* MKRingProgressView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MKRingProgressView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C07C89A2AF969F1008F604C /* AddPumpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddPumpView.swift; path = BioKernel/Views/AddPumpView.swift; sourceTree = SOURCE_ROOT; };
@@ -531,6 +535,7 @@
 				3B348D912B5D9AEE000A40E9 /* SafetyService.swift */,
 				3BE629B42AFCC8B6001526D4 /* SettingsStorage.swift */,
 				3B96F2AB2D0904EE00ABBA16 /* WatchCommsService.swift */,
+				3BF1631B2D20A6B700287BA0 /* WorkoutStatusService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -554,6 +559,7 @@
 				3B36F67A2B311BCE00008F4A /* NavigationModifier.swift */,
 				3B66FFA02C892EF600DB8CF2 /* SaveDataView.swift */,
 				3B6063B32B54BDFA009D9CBC /* SettingsView.swift */,
+				3BF1631D2D20D69F00287BA0 /* WorkoutStatusView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -804,9 +810,11 @@
 				3B96F29B2D08CD6B00ABBA16 /* SessionDelegator.swift in Sources */,
 				3B96F29F2D08CD6B00ABBA16 /* SessionCommands.swift in Sources */,
 				3BD7E2102C48A3AB0093D300 /* NotificationManager.swift in Sources */,
+				3BF1631C2D20A6B700287BA0 /* WorkoutStatusService.swift in Sources */,
 				3B6063B22B54BDB7009D9CBC /* DecimalPicker.swift in Sources */,
 				3B5329502B5D8451000DED1A /* AddedGlucoseDataFrame.swift in Sources */,
 				3B4052302B6DA87A004D232D /* AddedGlucoseModel.mlpackage in Sources */,
+				3BF1631E2D20D69F00287BA0 /* WorkoutStatusView.swift in Sources */,
 				3C7553CE2AFD610B00FAD880 /* StoredJsonObject.swift in Sources */,
 				3B6EC2322BD8131A008BFD4D /* AccErrorGauge.swift in Sources */,
 				3BD793832AF564EA00E5FDC9 /* DateExtensions.swift in Sources */,

--- a/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
+++ b/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		3BEE4E202B5FF4A000A09203 /* DateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BEE4E1F2B5FF4A000A09203 /* DateTime.swift */; };
 		3BF1631C2D20A6B700287BA0 /* WorkoutStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1631B2D20A6B700287BA0 /* WorkoutStatusService.swift */; };
 		3BF1631E2D20D69F00287BA0 /* WorkoutStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1631D2D20D69F00287BA0 /* WorkoutStatusView.swift */; };
+		3BF163202D217FE900287BA0 /* TargetGlucoseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1631F2D217FE900287BA0 /* TargetGlucoseService.swift */; };
 		3BF1BB262D0B1C2B00135F86 /* StoredJsonObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7553CD2AFD610B00FAD880 /* StoredJsonObject.swift */; };
 		3BF1BB272D0B1CA800135F86 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7553DD2AFDB2DA00FAD880 /* Debug.swift */; };
 		3BF1BB292D0B253000135F86 /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD793822AF564EA00E5FDC9 /* DateExtensions.swift */; };
@@ -274,6 +275,7 @@
 		3BEE4E1F2B5FF4A000A09203 /* DateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTime.swift; sourceTree = "<group>"; };
 		3BF1631B2D20A6B700287BA0 /* WorkoutStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutStatusService.swift; sourceTree = "<group>"; };
 		3BF1631D2D20D69F00287BA0 /* WorkoutStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutStatusView.swift; sourceTree = "<group>"; };
+		3BF1631F2D217FE900287BA0 /* TargetGlucoseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetGlucoseService.swift; sourceTree = "<group>"; };
 		3C07C88E2AF9625A008F604C /* OmniBLE.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OmniBLE.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C07C8972AF964E4008F604C /* MKRingProgressView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MKRingProgressView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C07C89A2AF969F1008F604C /* AddPumpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddPumpView.swift; path = BioKernel/Views/AddPumpView.swift; sourceTree = SOURCE_ROOT; };
@@ -534,6 +536,7 @@
 				3B6063C22B593821009D9CBC /* PhysiologicalModels.swift */,
 				3B348D912B5D9AEE000A40E9 /* SafetyService.swift */,
 				3BE629B42AFCC8B6001526D4 /* SettingsStorage.swift */,
+				3BF1631F2D217FE900287BA0 /* TargetGlucoseService.swift */,
 				3B96F2AB2D0904EE00ABBA16 /* WatchCommsService.swift */,
 				3BF1631B2D20A6B700287BA0 /* WorkoutStatusService.swift */,
 			);
@@ -834,6 +837,7 @@
 				3C7553DE2AFDB2DA00FAD880 /* Debug.swift in Sources */,
 				3B348D922B5D9AEE000A40E9 /* SafetyService.swift in Sources */,
 				3B6063B62B558EFA009D9CBC /* MachineLearning.swift in Sources */,
+				3BF163202D217FE900287BA0 /* TargetGlucoseService.swift in Sources */,
 				3B36F6792B311BAF00008F4A /* MainView.swift in Sources */,
 				3B36F6812B311E8F00008F4A /* GlucoseChartView.swift in Sources */,
 				3B348D902B5D9ADB000A40E9 /* Double.swift in Sources */,

--- a/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
+++ b/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		3BF1631C2D20A6B700287BA0 /* WorkoutStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1631B2D20A6B700287BA0 /* WorkoutStatusService.swift */; };
 		3BF1631E2D20D69F00287BA0 /* WorkoutStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1631D2D20D69F00287BA0 /* WorkoutStatusView.swift */; };
 		3BF163202D217FE900287BA0 /* TargetGlucoseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1631F2D217FE900287BA0 /* TargetGlucoseService.swift */; };
+		3BF163222D21A9B400287BA0 /* WorkoutStatusServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF163212D21A9B400287BA0 /* WorkoutStatusServiceTests.swift */; };
 		3BF1BB262D0B1C2B00135F86 /* StoredJsonObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7553CD2AFD610B00FAD880 /* StoredJsonObject.swift */; };
 		3BF1BB272D0B1CA800135F86 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7553DD2AFDB2DA00FAD880 /* Debug.swift */; };
 		3BF1BB292D0B253000135F86 /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD793822AF564EA00E5FDC9 /* DateExtensions.swift */; };
@@ -276,6 +277,7 @@
 		3BF1631B2D20A6B700287BA0 /* WorkoutStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutStatusService.swift; sourceTree = "<group>"; };
 		3BF1631D2D20D69F00287BA0 /* WorkoutStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutStatusView.swift; sourceTree = "<group>"; };
 		3BF1631F2D217FE900287BA0 /* TargetGlucoseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetGlucoseService.swift; sourceTree = "<group>"; };
+		3BF163212D21A9B400287BA0 /* WorkoutStatusServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutStatusServiceTests.swift; sourceTree = "<group>"; };
 		3C07C88E2AF9625A008F604C /* OmniBLE.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OmniBLE.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C07C8972AF964E4008F604C /* MKRingProgressView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MKRingProgressView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C07C89A2AF969F1008F604C /* AddPumpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddPumpView.swift; path = BioKernel/Views/AddPumpView.swift; sourceTree = SOURCE_ROOT; };
@@ -602,6 +604,7 @@
 				3B7C6D9B2B0C09320030DFA7 /* InsulinStorageTests.swift */,
 				3CBFB9892AFE02E90020FC90 /* InulinOnBoardTests.swift */,
 				3B348DAD2B5DAFB0000A40E9 /* SafetyServiceTests.swift */,
+				3BF163212D21A9B400287BA0 /* WorkoutStatusServiceTests.swift */,
 				3C15FE482B0C9C5000CA1FD4 /* Resources */,
 				3CAAFC8A2B0D719E00597055 /* Utils */,
 			);
@@ -898,6 +901,7 @@
 				3B7C6D9C2B0C09320030DFA7 /* InsulinStorageTests.swift in Sources */,
 				3BEE4E202B5FF4A000A09203 /* DateTime.swift in Sources */,
 				3CBFB98A2AFE02E90020FC90 /* InulinOnBoardTests.swift in Sources */,
+				3BF163222D21A9B400287BA0 /* WorkoutStatusServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/BioKernel/BioKernel.xcodeproj/xcshareddata/xcschemes/BioKernelWatch Watch App.xcscheme
+++ b/ios/BioKernel/BioKernel.xcodeproj/xcshareddata/xcschemes/BioKernelWatch Watch App.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3BE6DDCD2D08706D0032DD7F"
+               BuildableName = "BioKernelWatch Watch App.app"
+               BlueprintName = "BioKernelWatch Watch App"
+               ReferencedContainer = "container:BioKernel.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3B709A762AF4929D004E5885"
+               BuildableName = "BioKernel.app"
+               BlueprintName = "BioKernel"
+               ReferencedContainer = "container:BioKernel.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3BE6DDCD2D08706D0032DD7F"
+            BuildableName = "BioKernelWatch Watch App.app"
+            BlueprintName = "BioKernelWatch Watch App"
+            ReferencedContainer = "container:BioKernel.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3BE6DDCD2D08706D0032DD7F"
+            BuildableName = "BioKernelWatch Watch App.app"
+            BlueprintName = "BioKernelWatch Watch App"
+            ReferencedContainer = "container:BioKernel.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/BioKernel/BioKernel.xcodeproj/xcshareddata/xcschemes/LauncherWidgetExtension.xcscheme
+++ b/ios/BioKernel/BioKernel.xcodeproj/xcshareddata/xcschemes/LauncherWidgetExtension.xcscheme
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1610"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3B96F2512D08A2A800ABBA16"
+               BuildableName = "LauncherWidgetExtension.appex"
+               BlueprintName = "LauncherWidgetExtension"
+               ReferencedContainer = "container:BioKernel.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3B709A762AF4929D004E5885"
+               BuildableName = "BioKernel.app"
+               BlueprintName = "BioKernel"
+               ReferencedContainer = "container:BioKernel.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3BE6DDCD2D08706D0032DD7F"
+               BuildableName = "BioKernelWatch Watch App.app"
+               BlueprintName = "BioKernelWatch Watch App"
+               ReferencedContainer = "container:BioKernel.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3BE6DDCD2D08706D0032DD7F"
+            BuildableName = "BioKernelWatch Watch App.app"
+            BlueprintName = "BioKernelWatch Watch App"
+            ReferencedContainer = "container:BioKernel.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "_XCWidgetKind"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetDefaultView"
+            value = "timeline"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetFamily"
+            value = "systemMedium"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3B96F2512D08A2A800ABBA16"
+            BuildableName = "LauncherWidgetExtension.appex"
+            BlueprintName = "LauncherWidgetExtension"
+            ReferencedContainer = "container:BioKernel.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/BioKernel/BioKernel/BioKernelApp.swift
+++ b/ios/BioKernel/BioKernel/BioKernelApp.swift
@@ -16,6 +16,7 @@ struct BioKernelApp: App {
     init() {
         //G7CGMManager.debugLogger = getDebugLogger()
         getBackgroundService().registerBackgroundTask()
+        appDelegate.sessionDelegator.delegate = getWorkoutStatusService()
     }
     var body: some Scene {
         WindowGroup {
@@ -34,13 +35,11 @@ struct BioKernelApp: App {
 
 @MainActor
 class MyAppDelegate: NSObject, UIApplicationDelegate {
-    private lazy var sessionDelegator: SessionDelegator = {
-        return SessionDelegator()
-    }()
+    var sessionDelegator: SessionDelegator = SessionDelegator()
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
 
-        assert(WCSession.isSupported(), "This sample requires Watch Connectivity support!")
+        assert(WCSession.isSupported())
         WCSession.default.delegate = sessionDelegator
         WCSession.default.activate()
         

--- a/ios/BioKernel/BioKernel/DependencyInjection/Bindings.swift
+++ b/ios/BioKernel/BioKernel/DependencyInjection/Bindings.swift
@@ -28,3 +28,4 @@ let getDebugLogger: () -> G7DebugLogger = Dependency.bind { LocalEventLogger.sha
 let getBackgroundService: () -> BackgroundService = Dependency.bind { LocalBackgroundService.shared }
 let getGlucoseAlertsService: () -> GlucoseAlertStorage = Dependency.bind { PredictiveGlucoseAlertStorage.shared }
 let getWatchComms: () -> WatchComms = Dependency.bind { LocalWatchComms.shared }
+@MainActor let getWorkoutStatusService: () -> WorkoutStatusService = Dependency.bind { LocalWorkoutStatusService.shared }

--- a/ios/BioKernel/BioKernel/DependencyInjection/Bindings.swift
+++ b/ios/BioKernel/BioKernel/DependencyInjection/Bindings.swift
@@ -29,3 +29,4 @@ let getBackgroundService: () -> BackgroundService = Dependency.bind { LocalBackg
 let getGlucoseAlertsService: () -> GlucoseAlertStorage = Dependency.bind { PredictiveGlucoseAlertStorage.shared }
 let getWatchComms: () -> WatchComms = Dependency.bind { LocalWatchComms.shared }
 @MainActor let getWorkoutStatusService: () -> WorkoutStatusService = Dependency.bind { LocalWorkoutStatusService.shared }
+let getTargetGlucoseService: () -> TargetGlucoseService = Dependency.bind { LocalTargetGlucoseService.shared }

--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -296,7 +296,7 @@ actor LocalClosedLoopService: ClosedLoopService {
         let basalRate = settings.learnedBasalRate(at: at)
         let insulinSensitivity = settings.learnedInsulinSensitivity(at: at)
         let predictedGlucoseInMgDl = await getPhysiologicalModels().predictGlucoseIn15Minutes(from: at) ?? glucoseInMgDl
-        let targetGlucoseInMgDl = settings.targetGlucoseInMgDl
+        let targetGlucoseInMgDl = await getTargetGlucoseService().targetGlucoseInMgDl(at: at, settings: settings)
         
         let proportionalControllerStart = Date()
         let pidTempBasal = await getPhysiologicalModels().tempBasal(settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, insulinOnBoard: insulinOnBoard, dataFrame: dataFrame, at: at)

--- a/ios/BioKernel/BioKernel/Services/MachineLearning.swift
+++ b/ios/BioKernel/BioKernel/Services/MachineLearning.swift
@@ -10,7 +10,7 @@ import CoreML
 import LoopKit
 
 protocol MachineLearning {
-    func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> Double?
+    func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> Double?
 }
 
 struct MLUtilities {
@@ -50,14 +50,14 @@ actor LocalMachineLearning: MachineLearning {
     // our current prediction uses an ML model to predict addedGlucose
     // then runs it through the same calculations that we use for
     // our physiological models
-    func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> Double? {
+    func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> Double? {
         
         // For now we will always return nil for ML, the current model is highly
         // personalized for one individual and not appropriate for use in general.
         // But, it shows what we used when we ran experiments.
         return nil
         
-        let targetGlucose = settings.targetGlucoseInMgDl
+        let targetGlucose = targetGlucoseInMgDl
         let insulinSensitivity = settings.learnedInsulinSensitivity(at: at)
         let correctionDuration = settings.correctionDurationInSeconds
         

--- a/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
+++ b/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
@@ -23,7 +23,7 @@ struct PIDTempBasalResult: Codable {
 }
 
 protocol PhysiologicalModels {
-    func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> PIDTempBasalResult
+    func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> PIDTempBasalResult
     func predictGlucoseIn15Minutes(from: Date) async -> Double?
     func deltaGlucoseError(settings: CodableSettings, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> Double?
 }
@@ -94,8 +94,7 @@ actor LocalPhysiologicalModels: PhysiologicalModels {
         return error
     }
     
-    func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> PIDTempBasalResult {
-        let targetGlucose = settings.targetGlucoseInMgDl
+    func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> PIDTempBasalResult {
         let insulinSensitivity = settings.learnedInsulinSensitivity(at: at)
         let correctionDuration = settings.correctionDurationInSeconds
         let basalRate = settings.learnedBasalRate(at: at)
@@ -104,7 +103,7 @@ actor LocalPhysiologicalModels: PhysiologicalModels {
         let deltaGlucoseError = deltaGlucoseError(settings: settings, dataFrame: dataFrame, at: at)
         
         // PID controller
-        let error = glucoseInMgDl - targetGlucose
+        let error = glucoseInMgDl - targetGlucoseInMgDl
         var derivative = 0.0
         if let dt = lastGlucoseAt.map({ at.timeIntervalSince($0) }), dt < 11.minutesToSeconds(), let lastGlucose = lastGlucose {
             // these are slighly non-standard for PID but we do it this

--- a/ios/BioKernel/BioKernel/Services/SettingsStorage.swift
+++ b/ios/BioKernel/BioKernel/Services/SettingsStorage.swift
@@ -68,9 +68,11 @@ public struct CodableSettings: Codable {
     let pidIntegratorGain: Double?
     let pidDerivativeGain: Double?
     let useBiologicalInvariant: Bool?
+    let adjustTargetGlucoseDuringExercise: Bool?
     
     static let useMicroBolusDefault = false
     static let useBiologicalInvariantDefault = false
+    static let adjustTargetGlucoseDuringExerciseDefault = false
     static let microBolusDoseFactorDefault = 0.3
     static let bolusAmountForLessDefault = 2.0
     static let bolusAmountForUsualDefault = 3.0
@@ -84,6 +86,7 @@ public struct CodableSettings: Codable {
     
     func isMicroBolusEnabled() -> Bool { useMicroBolus ?? CodableSettings.useMicroBolusDefault }
     func isBiologicalInvariantEnabled() -> Bool { useBiologicalInvariant ?? CodableSettings.useBiologicalInvariantDefault}
+    func isTargetGlucoseAdjustedDuringExerciseEnabled() -> Bool { adjustTargetGlucoseDuringExercise ?? CodableSettings.adjustTargetGlucoseDuringExerciseDefault}
     
     func getMicroBolusDoseFactor() -> Double { microBolusDoseFactor ?? CodableSettings.microBolusDoseFactorDefault}
     func getPidIntegratorGain() -> Double { pidIntegratorGain ?? CodableSettings.pidIntegratorGainDefault }
@@ -108,7 +111,7 @@ public struct CodableSettings: Codable {
         }
     }
     
-    public init(created: Date, pumpBasalRateUnitsPerHour: Double, insulinSensitivityInMgDlPerUnit: Double, maxBasalRateUnitsPerHour: Double, maxBolusUnits: Double, shutOffGlucoseInMgDl: Double, targetGlucoseInMgDl: Double, closedLoopEnabled: Bool, useMachineLearningClosedLoop: Bool, useMicroBolus: Bool, microBolusDoseFactor: Double, learnedBasalRateUnitsPerHour: LearnedSettingsSchedule, learnedInsulinSensitivityInMgDlPerUnit: LearnedSettingsSchedule, bolusAmountForLess: Double, bolusAmountForUsual: Double, bolusAmountForMore: Double, pidIntegratorGain: Double, pidDerivativeGain: Double, useBiologicalInvariant: Bool) {
+    public init(created: Date, pumpBasalRateUnitsPerHour: Double, insulinSensitivityInMgDlPerUnit: Double, maxBasalRateUnitsPerHour: Double, maxBolusUnits: Double, shutOffGlucoseInMgDl: Double, targetGlucoseInMgDl: Double, closedLoopEnabled: Bool, useMachineLearningClosedLoop: Bool, useMicroBolus: Bool, microBolusDoseFactor: Double, learnedBasalRateUnitsPerHour: LearnedSettingsSchedule, learnedInsulinSensitivityInMgDlPerUnit: LearnedSettingsSchedule, bolusAmountForLess: Double, bolusAmountForUsual: Double, bolusAmountForMore: Double, pidIntegratorGain: Double, pidDerivativeGain: Double, useBiologicalInvariant: Bool, adjustTargetGlucoseDuringExercise: Bool) {
         self.created = created
         self.pumpBasalRateUnitsPerHour = pumpBasalRateUnitsPerHour
         self.insulinSensitivityInMgDlPerUnit = insulinSensitivityInMgDlPerUnit
@@ -128,6 +131,7 @@ public struct CodableSettings: Codable {
         self.pidIntegratorGain = pidIntegratorGain
         self.pidDerivativeGain = pidDerivativeGain
         self.useBiologicalInvariant = useBiologicalInvariant
+        self.adjustTargetGlucoseDuringExercise = adjustTargetGlucoseDuringExercise
         
         // Note: We hard code this at 30 minutes because of Omnipod limitations
         self.correctionDurationInSeconds = 30.minutesToSeconds()
@@ -136,7 +140,7 @@ public struct CodableSettings: Codable {
     }
     
     static func defaults() -> CodableSettings {
-        return CodableSettings(created: Date(), pumpBasalRateUnitsPerHour: 0.3, insulinSensitivityInMgDlPerUnit: 45, maxBasalRateUnitsPerHour: 2, maxBolusUnits: 5, shutOffGlucoseInMgDl: 85, targetGlucoseInMgDl: 90, closedLoopEnabled: false, useMachineLearningClosedLoop: false, useMicroBolus: useMicroBolusDefault, microBolusDoseFactor: microBolusDoseFactorDefault, learnedBasalRateUnitsPerHour: LearnedSettingsSchedule.empty(), learnedInsulinSensitivityInMgDlPerUnit: LearnedSettingsSchedule.empty(), bolusAmountForLess: bolusAmountForLessDefault, bolusAmountForUsual: bolusAmountForUsualDefault, bolusAmountForMore: bolusAmountForMoreDefault, pidIntegratorGain: pidIntegratorGainDefault, pidDerivativeGain: pidDerivativeGainDefault, useBiologicalInvariant: useBiologicalInvariantDefault)
+        return CodableSettings(created: Date(), pumpBasalRateUnitsPerHour: 0.3, insulinSensitivityInMgDlPerUnit: 45, maxBasalRateUnitsPerHour: 2, maxBolusUnits: 5, shutOffGlucoseInMgDl: 85, targetGlucoseInMgDl: 90, closedLoopEnabled: false, useMachineLearningClosedLoop: false, useMicroBolus: useMicroBolusDefault, microBolusDoseFactor: microBolusDoseFactorDefault, learnedBasalRateUnitsPerHour: LearnedSettingsSchedule.empty(), learnedInsulinSensitivityInMgDlPerUnit: LearnedSettingsSchedule.empty(), bolusAmountForLess: bolusAmountForLessDefault, bolusAmountForUsual: bolusAmountForUsualDefault, bolusAmountForMore: bolusAmountForMoreDefault, pidIntegratorGain: pidIntegratorGainDefault, pidDerivativeGain: pidDerivativeGainDefault, useBiologicalInvariant: useBiologicalInvariantDefault, adjustTargetGlucoseDuringExercise: adjustTargetGlucoseDuringExerciseDefault)
     }
 }
 

--- a/ios/BioKernel/BioKernel/Services/SettingsStorage.swift
+++ b/ios/BioKernel/BioKernel/Services/SettingsStorage.swift
@@ -53,7 +53,7 @@ public struct CodableSettings: Codable {
     let maxBasalRateUnitsPerHour: Double
     let maxBolusUnits: Double
     let shutOffGlucoseInMgDl: Double
-    let targetGlucoseInMgDl: Double
+    public let targetGlucoseInMgDl: Double
     let freshnessIntervalInSeconds: Double
     let correctionDurationInSeconds: Double
     let closedLoopEnabled: Bool

--- a/ios/BioKernel/BioKernel/Services/TargetGlucoseService.swift
+++ b/ios/BioKernel/BioKernel/Services/TargetGlucoseService.swift
@@ -1,0 +1,40 @@
+//
+//  TargetGlucoseService.swift
+//  BioKernel
+//
+//  Created by Sam King on 12/29/24.
+//
+
+// Note: for now this service is really simple -- it just deals with exercise
+// but eventually I can imagine meal predictions that lower the target
+// 1 hour before eating
+
+import Foundation
+
+public protocol TargetGlucoseService {
+    func targetGlucoseInMgDl(at: Date, settings: CodableSettings) async -> Double
+}
+
+actor LocalTargetGlucoseService: TargetGlucoseService {
+    let maxTargetGlucose = 140.0
+    let minTargetGlucose = 70.0
+    
+    static let shared = LocalTargetGlucoseService()
+
+    func targetGlucoseInMgDl(at: Date, settings: CodableSettings) async -> Double {
+        return await targetGlucoseInMgDlCalculation(at: at, settings: settings).clamp(low: minTargetGlucose, high: maxTargetGlucose)
+    }
+    
+    func targetGlucoseInMgDlCalculation(at: Date, settings: CodableSettings) async -> Double {
+        guard settings.isTargetGlucoseAdjustedDuringExerciseEnabled() else {
+            return settings.targetGlucoseInMgDl
+        }
+        
+        let isExercising = await getWorkoutStatusService().isExercising(at: at)
+        if isExercising {
+            return 140
+        } else {
+            return settings.targetGlucoseInMgDl
+        }
+    }
+}

--- a/ios/BioKernel/BioKernel/Services/WatchCommsService.swift
+++ b/ios/BioKernel/BioKernel/Services/WatchCommsService.swift
@@ -11,7 +11,7 @@ public protocol WatchComms {
     func updateAppContext() async
 }
 
-struct LocalWatchComms: WatchComms, SessionCommands {
+class LocalWatchComms: WatchComms, SessionCommands {
     static let shared = LocalWatchComms()
     
     func updateAppContext() async {

--- a/ios/BioKernel/BioKernel/Services/WorkoutStatusService.swift
+++ b/ios/BioKernel/BioKernel/Services/WorkoutStatusService.swift
@@ -8,34 +8,73 @@
 import Foundation
 import SwiftUI
 
-@MainActor protocol WorkoutStatusService: SessionUpdateDelegate {
+@MainActor
+protocol WorkoutStatusService: SessionUpdateDelegate {
     func observableObject() -> WorkoutStatus
+    func isExercising(at: Date) -> Bool
 }
 
 @MainActor
 class WorkoutStatus: ObservableObject {
     @Published var lastWorkoutMessage: WorkoutMessage? = nil
+    @Published var isExercising: Bool = false
 }
 
 @MainActor
 class LocalWorkoutStatusService: WorkoutStatusService {
+    struct WorkoutStatusState: Codable {
+        let lastMessageAt: Date?
+        let lastWorkoutMessage: WorkoutMessage?
+    }
     static let shared = LocalWorkoutStatusService()
     let storage = StoredJsonObject.create(fileName: "workoutStatus.json")
     let observable = WorkoutStatus()
+    var lastMessageAt: Date?
+    var lastWorkoutMessage: WorkoutMessage?
     
     func observableObject() -> WorkoutStatus {
         return observable
     }
+
+    func isExercising(at: Date) -> Bool {
+        let exercising = calculateIsExercising(at: at)
+        DispatchQueue.main.async {
+            self.observable.isExercising = exercising
+        }
+        return exercising
+    }
     
-    func didRecieveMessage(_ workout: WorkoutMessage) {
+    func calculateIsExercising(at: Date) -> Bool {
+        guard let lastMessageAt = lastMessageAt else { return false }
+
+        // make sure that we have gotten a fresh message within the last 60 minutes
+        // or else we will expire the exercise session automatically
+        guard at.timeIntervalSince(lastMessageAt) < 60.minutesToSeconds() else { return false }
+        
+        // check to make sure that our last message was to start a workout
+        switch (lastWorkoutMessage) {
+        case (.none):
+            return false
+        case (.ended):
+            return false
+        case (.started):
+            return true
+        }
+    }
+    
+    func didRecieveMessage(at: Date, workoutMessage: WorkoutMessage) {
         print("WC: WorkoutStatusService: didRecieveMessage")
+        lastMessageAt = at
+        lastWorkoutMessage = workoutMessage
         do {
-            try storage.write(workout)
+            try storage.write(WorkoutStatusState(lastMessageAt: lastMessageAt, lastWorkoutMessage: workoutMessage))
         } catch {
             print("unable to store workout message: \(error)")
         }
+        let exercising = calculateIsExercising(at: at)
         DispatchQueue.main.async {
-            self.observable.lastWorkoutMessage = workout
+            self.observable.lastWorkoutMessage = workoutMessage
+            self.observable.isExercising = exercising
         }
     }
     
@@ -44,6 +83,12 @@ class LocalWorkoutStatusService: WorkoutStatusService {
     }
     
     init() {
-        observable.lastWorkoutMessage = try? storage.read()
+        let state: WorkoutStatusState = (try? storage.read()) ?? WorkoutStatusState(lastMessageAt: nil, lastWorkoutMessage: nil)
+        lastMessageAt = state.lastMessageAt
+        lastWorkoutMessage = state.lastWorkoutMessage
+        
+        DispatchQueue.main.async {
+            self.observable.lastWorkoutMessage = state.lastWorkoutMessage
+        }
     }
 }

--- a/ios/BioKernel/BioKernel/Services/WorkoutStatusService.swift
+++ b/ios/BioKernel/BioKernel/Services/WorkoutStatusService.swift
@@ -1,0 +1,49 @@
+//
+//  WorkoutDisplayService.swift
+//  BioKernel
+//
+//  Created by Sam King on 12/28/24.
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor protocol WorkoutStatusService: SessionUpdateDelegate {
+    func observableObject() -> WorkoutStatus
+}
+
+@MainActor
+class WorkoutStatus: ObservableObject {
+    @Published var lastWorkoutMessage: WorkoutMessage? = nil
+}
+
+@MainActor
+class LocalWorkoutStatusService: WorkoutStatusService {
+    static let shared = LocalWorkoutStatusService()
+    let storage = StoredJsonObject.create(fileName: "workoutStatus.json")
+    let observable = WorkoutStatus()
+    
+    func observableObject() -> WorkoutStatus {
+        return observable
+    }
+    
+    func didRecieveMessage(_ workout: WorkoutMessage) {
+        print("WC: WorkoutStatusService: didRecieveMessage")
+        do {
+            try storage.write(workout)
+        } catch {
+            print("unable to store workout message: \(error)")
+        }
+        DispatchQueue.main.async {
+            self.observable.lastWorkoutMessage = workout
+        }
+    }
+    
+    func contextDidUpdate(_ context: BioKernelState) {
+        print("WC: contextDidUpdate not implemented")
+    }
+    
+    init() {
+        observable.lastWorkoutMessage = try? storage.read()
+    }
+}

--- a/ios/BioKernel/BioKernel/Services/WorkoutStatusService.swift
+++ b/ios/BioKernel/BioKernel/Services/WorkoutStatusService.swift
@@ -27,7 +27,7 @@ class LocalWorkoutStatusService: WorkoutStatusService {
         let lastWorkoutMessage: WorkoutMessage?
     }
     static let shared = LocalWorkoutStatusService()
-    let storage = StoredJsonObject.create(fileName: "workoutStatus.json")
+    let storage = getStoredObject().create(fileName: "workoutStatus.json")
     let observable = WorkoutStatus()
     var lastMessageAt: Date?
     var lastWorkoutMessage: WorkoutMessage?

--- a/ios/BioKernel/BioKernel/ViewModels/SettingsViewModel.swift
+++ b/ios/BioKernel/BioKernel/ViewModels/SettingsViewModel.swift
@@ -89,6 +89,7 @@ public class SettingsViewModel: ObservableObject {
     @Published var pidIntegratorGain: DecimalSetting
     @Published var pidDerivativeGain: DecimalSetting
     @Published var useBiologicalInvariant: Bool
+    @Published var adjustTargetGlucoseDuringExercise: Bool
     
     var mlBasalSchedule: DecimalSettingSchedule
     var mlInsulinSensitivitySchedule: DecimalSettingSchedule
@@ -154,6 +155,7 @@ public class SettingsViewModel: ObservableObject {
         pidIntegratorGain = DecimalSetting(value: settings.getPidIntegratorGain(), units: SettingsViewModel.gainUnits)
         pidDerivativeGain = DecimalSetting(value: settings.getPidDerivativeGain(), units: SettingsViewModel.gainUnits)
         useBiologicalInvariant = settings.isBiologicalInvariantEnabled()
+        adjustTargetGlucoseDuringExercise = settings.isTargetGlucoseAdjustedDuringExerciseEnabled()
     }
     
     public init(settings: CodableSettings) {
@@ -175,12 +177,13 @@ public class SettingsViewModel: ObservableObject {
         pidIntegratorGain = DecimalSetting(value: settings.getPidIntegratorGain(), units: SettingsViewModel.gainUnits)
         pidDerivativeGain = DecimalSetting(value: settings.getPidDerivativeGain(), units: SettingsViewModel.gainUnits)
         useBiologicalInvariant = settings.isBiologicalInvariantEnabled()
+        adjustTargetGlucoseDuringExercise = settings.isTargetGlucoseAdjustedDuringExerciseEnabled()
     }
     
     func snapshot() -> CodableSettings {
         let learnedBasalRate = LearnedSettingsSchedule.from(schedule: mlBasalSchedule)
         let learnedInsulinSensitivity = LearnedSettingsSchedule.from(schedule: mlInsulinSensitivitySchedule)
-        return CodableSettings(created: Date(), pumpBasalRateUnitsPerHour: pumpBasalRate.value, insulinSensitivityInMgDlPerUnit: insulinSensitivity.value, maxBasalRateUnitsPerHour: maxBasalRate.value, maxBolusUnits: maxBolus.value, shutOffGlucoseInMgDl: glucoseSafetyShutoff.value, targetGlucoseInMgDl: glucoseTarget.value, closedLoopEnabled: closedLoopEnabled, useMachineLearningClosedLoop: useMachineLearningClosedLoop, useMicroBolus: useMicroBolus, microBolusDoseFactor: microBolusDoseFactor.value, learnedBasalRateUnitsPerHour: learnedBasalRate, learnedInsulinSensitivityInMgDlPerUnit: learnedInsulinSensitivity, bolusAmountForLess: bolusAmountForLess.value, bolusAmountForUsual: bolusAmountForUsual.value, bolusAmountForMore: bolusAmountForMore.value, pidIntegratorGain: pidIntegratorGain.value, pidDerivativeGain: pidDerivativeGain.value, useBiologicalInvariant: useBiologicalInvariant)
+        return CodableSettings(created: Date(), pumpBasalRateUnitsPerHour: pumpBasalRate.value, insulinSensitivityInMgDlPerUnit: insulinSensitivity.value, maxBasalRateUnitsPerHour: maxBasalRate.value, maxBolusUnits: maxBolus.value, shutOffGlucoseInMgDl: glucoseSafetyShutoff.value, targetGlucoseInMgDl: glucoseTarget.value, closedLoopEnabled: closedLoopEnabled, useMachineLearningClosedLoop: useMachineLearningClosedLoop, useMicroBolus: useMicroBolus, microBolusDoseFactor: microBolusDoseFactor.value, learnedBasalRateUnitsPerHour: learnedBasalRate, learnedInsulinSensitivityInMgDlPerUnit: learnedInsulinSensitivity, bolusAmountForLess: bolusAmountForLess.value, bolusAmountForUsual: bolusAmountForUsual.value, bolusAmountForMore: bolusAmountForMore.value, pidIntegratorGain: pidIntegratorGain.value, pidDerivativeGain: pidDerivativeGain.value, useBiologicalInvariant: useBiologicalInvariant, adjustTargetGlucoseDuringExercise: adjustTargetGlucoseDuringExercise)
     }
 }
 

--- a/ios/BioKernel/BioKernel/Views/MainViewSummaryView.swift
+++ b/ios/BioKernel/BioKernel/Views/MainViewSummaryView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct MainViewSummaryView: View {
     @StateObject var deviceManagerObservable = getDeviceDataManager().observableObject()
     @ObservedObject var glucoseAlertsViewModel = getGlucoseAlertsService().viewModel()
+    @ObservedObject var workoutStatus = getWorkoutStatusService().observableObject()
     @Environment(\.scenePhase) var scenePhase
     @State var timer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
     @State var predictedGlucose: Double?
@@ -64,6 +65,15 @@ struct MainViewSummaryView: View {
                 .frame(maxWidth: .infinity)
             }
             .padding([.bottom])
+            switch (workoutStatus.lastWorkoutMessage) {
+            case (.none):
+                EmptyView()
+            case (.started(let at, let description, let imageName)):
+                WorkoutStatusView(at: at, description: description, imageName: imageName)
+                    .padding()
+            case (.ended):
+                EmptyView()
+            }
         }
         .foregroundColor(.white)
         .frame(maxWidth: .infinity)

--- a/ios/BioKernel/BioKernel/Views/MainViewSummaryView.swift
+++ b/ios/BioKernel/BioKernel/Views/MainViewSummaryView.swift
@@ -65,13 +65,15 @@ struct MainViewSummaryView: View {
                 .frame(maxWidth: .infinity)
             }
             .padding([.bottom])
-            switch (workoutStatus.lastWorkoutMessage) {
-            case (.none):
+            switch (getSettingsStorage().snapshot().isTargetGlucoseAdjustedDuringExerciseEnabled(),  workoutStatus.lastWorkoutMessage) {
+            case (false, _):
                 EmptyView()
-            case (.started(let at, let description, let imageName)):
+            case (true, .none):
+                EmptyView()
+            case (true, .started(let at, let description, let imageName)):
                 WorkoutStatusView(at: at, description: description, imageName: imageName)
                     .padding()
-            case (.ended):
+            case (true, .ended):
                 EmptyView()
             }
         }

--- a/ios/BioKernel/BioKernel/Views/MainViewSummaryView.swift
+++ b/ios/BioKernel/BioKernel/Views/MainViewSummaryView.swift
@@ -65,15 +65,17 @@ struct MainViewSummaryView: View {
                 .frame(maxWidth: .infinity)
             }
             .padding([.bottom])
-            switch (getSettingsStorage().snapshot().isTargetGlucoseAdjustedDuringExerciseEnabled(),  workoutStatus.lastWorkoutMessage) {
-            case (false, _):
+            switch (getSettingsStorage().snapshot().isTargetGlucoseAdjustedDuringExerciseEnabled(),  workoutStatus.isExercising, workoutStatus.lastWorkoutMessage) {
+            case (false, _, _):
                 EmptyView()
-            case (true, .none):
+            case (true, false, _):
                 EmptyView()
-            case (true, .started(let at, let description, let imageName)):
+            case (true, true, .none):
+                EmptyView()
+            case (true, true, .started(let at, let description, let imageName)):
                 WorkoutStatusView(at: at, description: description, imageName: imageName)
                     .padding()
-            case (true, .ended):
+            case (true, true, .ended):
                 EmptyView()
             }
         }

--- a/ios/BioKernel/BioKernel/Views/SettingsView.swift
+++ b/ios/BioKernel/BioKernel/Views/SettingsView.swift
@@ -30,6 +30,11 @@ struct SettingsView: View {
                     }.onChange(of: settingsViewModel.closedLoopEnabled) { _ in
                         hasModifications = true
                     }
+                    Toggle(isOn: $settingsViewModel.adjustTargetGlucoseDuringExercise) {
+                        Text("Adjust target glucose during exercise")
+                    }.onChange(of: settingsViewModel.adjustTargetGlucoseDuringExercise) { _ in
+                        hasModifications = true
+                    }
                     Toggle(isOn: $settingsViewModel.useMachineLearningClosedLoop) {
                         Text("Use ML closed loop")
                     }.onChange(of: settingsViewModel.useMachineLearningClosedLoop) { _ in

--- a/ios/BioKernel/BioKernel/Views/WorkoutStatusView.swift
+++ b/ios/BioKernel/BioKernel/Views/WorkoutStatusView.swift
@@ -11,8 +11,10 @@ struct WorkoutStatusView: View {
     let description: String
     let imageName: String
     
+    @State var timer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
+    @Environment(\.scenePhase) var scenePhase
     @State private var currentTime = Date()
-    let timer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
+
     
     private var duration: Int {
         Int(currentTime.timeIntervalSince(at) / 60.0)
@@ -40,6 +42,7 @@ struct WorkoutStatusView: View {
             // Workout Info
             VStack(alignment: .leading, spacing: 4) {
                 Text(description)
+                    .foregroundColor(.primary)
                     .font(.headline)
                 HStack(spacing: 4) {
                     Image(systemName: "clock")
@@ -73,8 +76,16 @@ struct WorkoutStatusView: View {
                 .fill(Color(.systemBackground))
                 .shadow(color: .black.opacity(0.05), radius: 8, x: 0, y: 2)
         )
-        .onReceive(timer) { time in
-            currentTime = time
+        .onChange(of: scenePhase) { newPhase in
+            if newPhase == .inactive || newPhase == .background {
+                self.timer.upstream.connect().cancel()
+            } else if newPhase == .active {
+                self.timer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
+                currentTime = Date()
+            }
+        }
+        .onReceive(timer) { _ in
+            currentTime = Date()
         }
     }
 }

--- a/ios/BioKernel/BioKernel/Views/WorkoutStatusView.swift
+++ b/ios/BioKernel/BioKernel/Views/WorkoutStatusView.swift
@@ -1,0 +1,84 @@
+//
+//  WorkoutStatusView.swift
+//  BioKernel
+//
+//  Created by Sam King on 12/28/24.
+//
+import SwiftUI
+
+struct WorkoutStatusView: View {
+    let at: Date
+    let description: String
+    let imageName: String
+    
+    @State private var currentTime = Date()
+    let timer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
+    
+    private var duration: Int {
+        Int(currentTime.timeIntervalSince(at) / 60.0)
+    }
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            // Activity Icon
+            ZStack {
+                Circle()
+                    .fill(Color.blue.opacity(0.15))
+                    .frame(width: 50, height: 50)
+                
+                Image(systemName: imageName)
+                    .font(.title2)
+                    .foregroundStyle(.blue)
+                
+                // Active indicator
+                Circle()
+                    .fill(Color.green)
+                    .frame(width: 10, height: 10)
+                    .offset(x: 18, y: -18)
+            }
+            
+            // Workout Info
+            VStack(alignment: .leading, spacing: 4) {
+                Text(description)
+                    .font(.headline)
+                HStack(spacing: 4) {
+                    Image(systemName: "clock")
+                        .foregroundColor(.secondary)
+                        .font(.footnote)
+                    Text("\(duration)m")
+                        .foregroundColor(.secondary)
+                        .font(.subheadline)
+                }
+            }
+            
+            Spacer()
+            
+            // Target Info
+            VStack(alignment: .trailing, spacing: 4) {
+                Text("Target")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Text("140")
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.blue)
+                Text(" mg/dL")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.systemBackground))
+                .shadow(color: .black.opacity(0.05), radius: 8, x: 0, y: 2)
+        )
+        .onReceive(timer) { time in
+            currentTime = time
+        }
+    }
+}
+
+#Preview {
+    WorkoutStatusView(at: Date(), description: "Running", imageName: "figure.run")
+}

--- a/ios/BioKernel/BioKernel/WatchCommsShared/CommandStatus.swift
+++ b/ios/BioKernel/BioKernel/WatchCommsShared/CommandStatus.swift
@@ -40,6 +40,7 @@ struct CommandStatus {
     var command: Command
     var phrase: Phrase
     var bioKernelState: BioKernelState?
+    var workoutMessage: WorkoutMessage?
     var errorMessage: String?
     
     init(command: Command, phrase: Phrase) {

--- a/ios/BioKernel/BioKernel/WatchCommsShared/SessionDelegator.swift
+++ b/ios/BioKernel/BioKernel/WatchCommsShared/SessionDelegator.swift
@@ -24,7 +24,7 @@ extension Notification.Name {
 @MainActor
 protocol SessionUpdateDelegate: AnyObject {
     func contextDidUpdate(_ context: BioKernelState)
-    func didRecieveMessage(_ workout: WorkoutMessage)
+    func didRecieveMessage(at: Date, workoutMessage: WorkoutMessage)
 }
 
 class SessionDelegator: NSObject, WCSessionDelegate {
@@ -100,7 +100,7 @@ class SessionDelegator: NSObject, WCSessionDelegate {
             print("WC: Checking message")
             if let workoutMessage = object?.workoutMessage, name == .dataDidFlow {
                 print("WC: got new message")
-                self?.delegate?.didRecieveMessage(workoutMessage)
+                self?.delegate?.didRecieveMessage(at: Date(), workoutMessage: workoutMessage)
             }
             print("WC: Done checking message")
         }

--- a/ios/BioKernel/BioKernel/WatchCommsShared/WatchComms.swift
+++ b/ios/BioKernel/BioKernel/WatchCommsShared/WatchComms.swift
@@ -14,7 +14,7 @@ struct PayloadKeys {
     static let insulinOnBoard = "insulinOnBoard"
 }
 
-enum WorkoutMessage: Codable {
+public enum WorkoutMessage: Codable {
     case started(at: Date, description: String, imageName: String)
     case ended(at: Date)
 }

--- a/ios/BioKernel/BioKernel/WatchCommsShared/WatchComms.swift
+++ b/ios/BioKernel/BioKernel/WatchCommsShared/WatchComms.swift
@@ -14,6 +14,11 @@ struct PayloadKeys {
     static let insulinOnBoard = "insulinOnBoard"
 }
 
+enum WorkoutMessage: Codable {
+    case started(at: Date, description: String, imageName: String)
+    case ended(at: Date)
+}
+
 struct StateGlucoseReadings: Codable {
     let at: Date
     let glucoseReadingInMgDl: Double

--- a/ios/BioKernel/BioKernelTests/ClosedLoopTests.swift
+++ b/ios/BioKernel/BioKernelTests/ClosedLoopTests.swift
@@ -56,7 +56,7 @@ final class ClosedLoopTests: XCTestCase {
         // this is just for logging
         let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
 
-        let dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
+        let dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 1.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
@@ -70,7 +70,7 @@ final class ClosedLoopTests: XCTestCase {
         // this is just for logging
         let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
 
-        let dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
+        let dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 1.5, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
@@ -84,7 +84,7 @@ final class ClosedLoopTests: XCTestCase {
         // this is just for logging
         let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
 
-        let dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
+        let dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.25, accuracy: iobAccuracy)
@@ -98,16 +98,31 @@ final class ClosedLoopTests: XCTestCase {
         // this is just for logging
         let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
 
-        var dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
+        var dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.2, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.02, microBolusSafety: 0.25, biologicalInvariant: nil)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.02, microBolusSafety: 0.25, biologicalInvariant: nil, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 1.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
     }
+    
+    func testDoseLogicDisableMicroBolusFromExercise() async {
+        let closedLoop = LocalClosedLoopService()
+        let settings = await MockSettingsStorage()
+        await settings.update(useMicroBolus: true, useMachineLearningClosedLoop: false, useBiologicalInvariant: false)
+        
+        // this is just for logging
+        let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
+
+        var dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, isExercising: true)
+        
+        XCTAssertEqual(dose.tempBasal, 1.0, accuracy: iobAccuracy)
+        XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
+    }
+    
     
     func testDoseLogicUseBiologicalInvariant() async {
         let closedLoop = LocalClosedLoopService()
@@ -117,17 +132,17 @@ final class ClosedLoopTests: XCTestCase {
         // this is just for logging
         let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
 
-        var dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25)
+        var dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 1.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 1.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
@@ -141,17 +156,17 @@ final class ClosedLoopTests: XCTestCase {
         // this is just for logging
         let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
 
-        var dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25)
+        var dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.2, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.2, accuracy: iobAccuracy)
@@ -165,17 +180,17 @@ final class ClosedLoopTests: XCTestCase {
         // this is just for logging
         let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
 
-        var dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25)
+        var dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 1.5, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 1.5, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
@@ -189,17 +204,17 @@ final class ClosedLoopTests: XCTestCase {
         // this is just for logging
         let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
 
-        var dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25)
+        var dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.25, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), safetyTempBasalResult: safetyTempBasalResult, physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, isExercising: false)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.25, accuracy: iobAccuracy)

--- a/ios/BioKernel/BioKernelTests/Utils/MockClasses.swift
+++ b/ios/BioKernel/BioKernelTests/Utils/MockClasses.swift
@@ -38,6 +38,7 @@ class MockSettingsStorage: SettingsStorage {
     var pidIntegratorGain = 0.055
     var pidDerivativeGain = 0.35
     var useBiologicalInvariant = false
+    var adjustTargetGlucoseDuringExercise = false
     
     func update(useMicroBolus: Bool, useMachineLearningClosedLoop: Bool, useBiologicalInvariant: Bool) {
         self.useMicroBolus = useMicroBolus
@@ -46,7 +47,7 @@ class MockSettingsStorage: SettingsStorage {
     }
     
     func snapshot() -> BioKernel.CodableSettings {
-        return CodableSettings(created: Date(), pumpBasalRateUnitsPerHour: pumpBasalRateUnitsPerHour, insulinSensitivityInMgDlPerUnit: insulinSensitivityInMgDlPerUnit, maxBasalRateUnitsPerHour: maxBasalRateUnitsPerHour, maxBolusUnits: maxBolusUnits, shutOffGlucoseInMgDl: shutOffGlucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, closedLoopEnabled: closedLoopEnabled, useMachineLearningClosedLoop: useMachineLearningClosedLoop, useMicroBolus: useMicroBolus, microBolusDoseFactor: microBolusDoseFactor, learnedBasalRateUnitsPerHour: learnedBasalRateUnitsPerHour, learnedInsulinSensitivityInMgDlPerUnit: learnedInsulinSensitivityInMgDlPerUnit, bolusAmountForLess: bolusAmountForLess, bolusAmountForUsual: bolusAmountForUsual, bolusAmountForMore: bolusAmountForMore, pidIntegratorGain: pidIntegratorGain, pidDerivativeGain: pidDerivativeGain, useBiologicalInvariant: useBiologicalInvariant)
+        return CodableSettings(created: Date(), pumpBasalRateUnitsPerHour: pumpBasalRateUnitsPerHour, insulinSensitivityInMgDlPerUnit: insulinSensitivityInMgDlPerUnit, maxBasalRateUnitsPerHour: maxBasalRateUnitsPerHour, maxBolusUnits: maxBolusUnits, shutOffGlucoseInMgDl: shutOffGlucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, closedLoopEnabled: closedLoopEnabled, useMachineLearningClosedLoop: useMachineLearningClosedLoop, useMicroBolus: useMicroBolus, microBolusDoseFactor: microBolusDoseFactor, learnedBasalRateUnitsPerHour: learnedBasalRateUnitsPerHour, learnedInsulinSensitivityInMgDlPerUnit: learnedInsulinSensitivityInMgDlPerUnit, bolusAmountForLess: bolusAmountForLess, bolusAmountForUsual: bolusAmountForUsual, bolusAmountForMore: bolusAmountForMore, pidIntegratorGain: pidIntegratorGain, pidDerivativeGain: pidDerivativeGain, useBiologicalInvariant: useBiologicalInvariant, adjustTargetGlucoseDuringExercise: adjustTargetGlucoseDuringExercise)
     }
     
     func writeToDisk(settings: BioKernel.CodableSettings) throws {

--- a/ios/BioKernel/BioKernelTests/Utils/MockClasses.swift
+++ b/ios/BioKernel/BioKernelTests/Utils/MockClasses.swift
@@ -67,6 +67,12 @@ class MockWatchComms: WatchComms {
     func updateAppContext() async { }
 }
 
+class MockTargetGlucose: TargetGlucoseService {
+    func targetGlucoseInMgDl(at: Date, settings: BioKernel.CodableSettings) async -> Double {
+        return settings.targetGlucoseInMgDl
+    }
+}
+
 class MockReplayLogger: EventLogger {
     func update(deviceToken: String) async { }
     func upload(healthKitRecords: BioKernel.HealthKitRecords) async -> Bool { return false }

--- a/ios/BioKernel/BioKernelTests/WorkoutStatusServiceTests.swift
+++ b/ios/BioKernel/BioKernelTests/WorkoutStatusServiceTests.swift
@@ -1,0 +1,64 @@
+//
+//  WorkoutStatusServiceTests.swift
+//  BioKernelTests
+//
+//  Created by Sam King on 12/29/24.
+//
+
+import XCTest
+
+@testable import BioKernel
+
+final class WorkoutStatusServiceTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        Dependency.useMockConstructors = true
+        Dependency.mock { MockStoredObject.self as StoredObject.Type }
+    }
+
+    override func tearDownWithError() throws {
+        Dependency.resetMocks()
+        Dependency.useMockConstructors = false
+    }
+
+    func testWorkout() async throws {
+        let startDate = Date.f("2018-07-15 03:34:29 +0000")
+        let workoutStartMessage: WorkoutMessage = .started(at: startDate + 1, description: "Run", imageName: "figure.run")
+        let workoutEndMessage: WorkoutMessage = .ended(at: startDate + 3)
+        let workoutStatus = await LocalWorkoutStatusService()
+        
+        // no messages
+        var isExercising = await workoutStatus.isExercising(at: startDate)
+        XCTAssert(!isExercising)
+        
+        // started a workout
+        await workoutStatus.didRecieveMessage(at: startDate + 1, workoutMessage: workoutStartMessage)
+        isExercising = await workoutStatus.isExercising(at: startDate + 2)
+        XCTAssert(isExercising)
+        
+        // ended a workout
+        await workoutStatus.didRecieveMessage(at: startDate + 3, workoutMessage: workoutEndMessage)
+        isExercising = await workoutStatus.isExercising(at: startDate + 4)
+        XCTAssert(!isExercising)
+    }
+    
+    func testWorkoutTimeout() async throws {
+        let startDate = Date.f("2018-07-15 03:34:29 +0000")
+        let workoutStartMessage: WorkoutMessage = .started(at: startDate, description: "Run", imageName: "figure.run")
+        let workoutStatus = await LocalWorkoutStatusService()
+                
+        // test right before the timeout
+        await workoutStatus.didRecieveMessage(at: startDate, workoutMessage: workoutStartMessage)
+        var isExercising = await workoutStatus.isExercising(at: startDate + 59.minutesToSeconds())
+        XCTAssert(isExercising)
+        
+        // right after the timeout
+        isExercising = await workoutStatus.isExercising(at: startDate + 61.minutesToSeconds())
+        XCTAssert(!isExercising)
+        
+        // get a new message and restart the timer
+        await workoutStatus.didRecieveMessage(at: startDate + 59.minutesToSeconds(), workoutMessage: workoutStartMessage)
+        isExercising = await workoutStatus.isExercising(at: startDate + 61.minutesToSeconds())
+        XCTAssert(isExercising)
+    }
+}

--- a/ios/BioKernel/BioKernelWatch Watch App/StateViewModel.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/StateViewModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 @MainActor
 class StateViewModel: ObservableObject, SessionUpdateDelegate {
-    func didRecieveMessage(_ workout: WorkoutMessage) {
+    func didRecieveMessage(at: Date, workoutMessage: WorkoutMessage) {
         print("not implemented")
     }
     

--- a/ios/BioKernel/BioKernelWatch Watch App/StateViewModel.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/StateViewModel.swift
@@ -10,7 +10,10 @@ import SwiftUI
 
 @MainActor
 class StateViewModel: ObservableObject, SessionUpdateDelegate {
-    static let shared = StateViewModel()
+    func didRecieveMessage(_ workout: WorkoutMessage) {
+        print("not implemented")
+    }
+    
     let storage = StoredJsonObject.create(fileName: "appState.json")
     func contextDidUpdate(_ context: BioKernelState) {
         print("WC: StateViewModel: contextDidUpdate")

--- a/ios/BioKernel/BioKernelWatch Watch App/Workout/Workout.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/Workout/Workout.swift
@@ -13,6 +13,7 @@ struct Workout {
     let activityType: HKWorkoutActivityType
     let locationType: HKWorkoutSessionLocationType
     let image: Image
+    let imageName: String
     
     private init(description: String,
                 activityType: HKWorkoutActivityType,
@@ -21,6 +22,7 @@ struct Workout {
         self.description = description
         self.activityType = activityType
         self.locationType = locationType
+        self.imageName = imageName
         self.image = Image(systemName: imageName)
     }
     

--- a/ios/BioKernel/BioKernelWatch Watch App/Workout/WorkoutManager.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/Workout/WorkoutManager.swift
@@ -10,7 +10,7 @@ import Foundation
 import HealthKit
 import WatchKit
 
-class WorkoutManager: NSObject, ObservableObject {
+class WorkoutManager: NSObject, ObservableObject, SessionCommands {
     var selectedWorkout: Workout? {
         didSet {
             guard let selectedWorkout = selectedWorkout else { return }
@@ -42,6 +42,7 @@ class WorkoutManager: NSObject, ObservableObject {
         
         let startDate = Date()
         session.startActivity(with: startDate)
+        sendMessageData(workoutMessage: .started(at: startDate, description: workout.description, imageName: workout.imageName))
         builder?.beginCollection(withStart: startDate) { (success, error) in
             // the workout has started
         }
@@ -90,6 +91,7 @@ class WorkoutManager: NSObject, ObservableObject {
     }
     
     func end(save: Bool) {
+        sendMessageData(workoutMessage: .ended(at: Date()))
         if save {
             session?.end()
         } else {


### PR DESCRIPTION
This PR includes code for automatically detecting exercise initiated from the watch app and raising the target glucose level in response. There are two important parts to this PR:
- The actual change, there are some subtleties around ending exercise and for now we (1) rely on the watch to send commands (2) timeout after 1 hour, and (3) people can disable this via settings as a last resort.
- We included a target glucose service to give us the ability to adjust target glucose levels at key points in time, like when predicted to eat.