### PR TITLE
Update AI dosing to only dose when more than PID

### DIFF
--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -176,7 +176,7 @@ actor LocalClosedLoopService: ClosedLoopService {
         
         // calculate the ML-based tempBasal
         let mlStart = Date()
-        let mlTempBasalRaw = await getMachineLearning().tempBasal(settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, insulinOnBoard: insulinOnBoard, dataFrame: dataFrame, at: at) ?? physiologicalTempBasal
+        let mlTempBasalRaw = await getMachineLearning().tempBasal(settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, insulinOnBoard: insulinOnBoard, dataFrame: dataFrame, at: at, pidTempBasal: pidTempBasal) ?? physiologicalTempBasal
         let mlTempBasal = applyGuardrails(glucoseInMgDl: glucoseInMgDl, predictedGlucoseInMgDl: predictedGlucoseInMgDl, newBasalRateRaw: mlTempBasalRaw, settings: settings, roundToSupportedBasalRate: roundToSupportedBasalRate)
         let mlDuration = Date().timeIntervalSince(mlStart)
         

--- a/ios/BioKernel/BioKernelTests/Utils/MockClasses.swift
+++ b/ios/BioKernel/BioKernelTests/Utils/MockClasses.swift
@@ -110,7 +110,7 @@ class MockSettingsStorage: SettingsStorage {
 }
 
 class MockMachineLearning: MachineLearning {
-    func tempBasal(settings: BioKernel.CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [BioKernel.AddedGlucoseDataRow]?, at: Date) async -> Double? {
+    func tempBasal(settings: BioKernel.CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [BioKernel.AddedGlucoseDataRow]?, at: Date, pidTempBasal: PIDTempBasalResult) async -> Double? {
         return nil
     }
 }


### PR DESCRIPTION
Our AI dosing algorithm is just for adding insulin during active digestion, so we only activate it if it wants to dose more than the "reactive safe" PID controller.