### PR TITLE
Expose filtered glucose values in the UI

### DIFF
--- a/ios/BioKernel/BioKernel/LoopKitSupport/DeviceDataManager.swift
+++ b/ios/BioKernel/BioKernel/LoopKitSupport/DeviceDataManager.swift
@@ -63,6 +63,7 @@ public protocol DeviceDataManager {
     func update(insulinOnBoard: Double, pumpAlarm: PumpAlarmType?)
     func update(activeAlert: LoopKit.Alert?)
     func update(glucoseChartData: [GlucoseChartPoint])
+    func update(filteredGlucoseChartData: [FilteredGlucose])
     func update(totalAmount: Double, bolusProgressReporter: DoseProgressReporter)
     
     func cgmPumpMetadata() async -> CgmPumpMetadata
@@ -79,6 +80,7 @@ public class DeviceDataManagerObservableObject: ObservableObject {
     @Published public var lastClosedLoopRun: ClosedLoopResult? = nil
     @Published public var activeAlert: LoopKit.Alert? = nil
     @Published public var glucoseChartData: [GlucoseChartPoint] = []
+    @Published public var filteredGlucoseChartData: [FilteredGlucose] = []
     @Published public var doseProgress: DoseProgress = DoseProgress()
     
     public init() {
@@ -268,6 +270,12 @@ class LocalDeviceDataManager: DeviceDataManager {
     func update(activeAlert: LoopKit.Alert?) {
         DispatchQueue.main.async {
             self.localObservableObject.activeAlert = activeAlert
+        }
+    }
+    
+    func update(filteredGlucoseChartData: [FilteredGlucose]) {
+        DispatchQueue.main.async {
+            self.localObservableObject.filteredGlucoseChartData = filteredGlucoseChartData
         }
     }
     

--- a/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
+++ b/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
@@ -13,6 +13,7 @@ public struct PIDTempBasalResult: Codable {
     public let Kp: Double
     public let Ki: Double
     public let Kd: Double
+    public let filteredGlucose: Double
     public let error: Double
     public let tempBasal: Double
     public let accumulatedError: Double
@@ -21,11 +22,12 @@ public struct PIDTempBasalResult: Codable {
     public let lastGlucoseAt: Date?
     public let deltaGlucoseError: Double?
     
-    public init(at: Date, Kp: Double, Ki: Double, Kd: Double, error: Double, tempBasal: Double, accumulatedError: Double, derivative: Double?, lastGlucose: Double?, lastGlucoseAt: Date?, deltaGlucoseError: Double?) {
+    public init(at: Date, Kp: Double, Ki: Double, Kd: Double, filteredGlucose: Double, error: Double, tempBasal: Double, accumulatedError: Double, derivative: Double?, lastGlucose: Double?, lastGlucoseAt: Date?, deltaGlucoseError: Double?) {
         self.at = at
         self.Kp = Kp
         self.Ki = Ki
         self.Kd = Kd
+        self.filteredGlucose = filteredGlucose
         self.error = error
         self.tempBasal = tempBasal
         self.accumulatedError = accumulatedError
@@ -168,7 +170,7 @@ actor LocalPhysiologicalModels: PhysiologicalModels {
         // add the basalRate back in so that our default when the correctionAmount is 0 is basalRate
         let tempBasal = correctionAmount * 1.hoursToSeconds() / correctionDuration + basalRate
         
-        let result = PIDTempBasalResult(at: at, Kp: Kp, Ki: Ki, Kd: Kd, error: error, tempBasal: tempBasal, accumulatedError: accumulatedError, derivative: derivative, lastGlucose: lastGlucose, lastGlucoseAt: lastGlucoseAt, deltaGlucoseError: deltaGlucoseError)
+        let result = PIDTempBasalResult(at: at, Kp: Kp, Ki: Ki, Kd: Kd, filteredGlucose: filteredGlucose, error: error, tempBasal: tempBasal, accumulatedError: accumulatedError, derivative: derivative, lastGlucose: lastGlucose, lastGlucoseAt: lastGlucoseAt, deltaGlucoseError: deltaGlucoseError)
         lastGlucose = glucoseInMgDl
         lastGlucoseAt = at
         lastFilteredGlucose = filteredGlucose

--- a/ios/BioKernel/BioKernel/Views/GlucoseChartView.swift
+++ b/ios/BioKernel/BioKernel/Views/GlucoseChartView.swift
@@ -47,6 +47,12 @@ struct GlucoseChartView: View {
                     .symbolSize(10)  // Adjust the size of the points
                     .foregroundStyle(.blue)
             }
+            ForEach(deviceManagerObservable.filteredGlucoseChartData, id: \.at) { reading in
+                LineMark(x: .value("Time", reading.at),
+                         y: .value("mg/dL", reading.glucose))
+                    .symbolSize(5)  // Adjust the size of the points
+                    .foregroundStyle(.purple)
+            }
         }
         .chartYScale(domain: 0...maxY)
         .chartXScale(domain: minX...maxX)


### PR DESCRIPTION
This PR exposes filtered glucose values to the UI. It includes changes to store up to 24 hours worth of closed loop results and pulls the values from this store for display. It follows the same pattern as glucose display for visualization.