### PR TITLE
Update the glucose chart view to use different time ranges

### DIFF
--- a/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
+++ b/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
@@ -1094,7 +1094,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.getgrowthmetrics.BioKernel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1131,7 +1131,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.getgrowthmetrics.BioKernel;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/BioKernel/BioKernel/Views/GlucoseChartView.swift
+++ b/ios/BioKernel/BioKernel/Views/GlucoseChartView.swift
@@ -31,11 +31,7 @@ struct GlucoseChartView: View {
     }
 
     private var strideInHours: Int {
-#if os(watchOS)
-        return 3
-#else
         return selectedHours > 6 ? 2 : 1
-#endif
     }
 
     private func chart(geometry: GeometryProxy) -> some View {
@@ -64,7 +60,8 @@ struct GlucoseChartView: View {
                     .foregroundStyle(.purple)
             }
         }
-        .frame(width: geometry.size.width * CGFloat(24 / selectedHours))
+        // avoid divide by 0
+        .frame(width: geometry.size.width * CGFloat(24 / (selectedHours == 0 ? 4 : selectedHours)))
         .chartYScale(domain: 0...maxY)
         .chartXScale(domain: timeWindow.min...timeWindow.max)
         .chartXAxis {

--- a/ios/BioKernel/BioKernel/Views/GlucoseChartView.swift
+++ b/ios/BioKernel/BioKernel/Views/GlucoseChartView.swift
@@ -10,33 +10,42 @@ import SwiftUI
 
 struct GlucoseChartView: View {
     @StateObject var deviceManagerObservable = getDeviceDataManager().observableObject()
-    var body: some View {
-        let maxY = { () -> Int in
-            let readings = deviceManagerObservable.glucoseChartData.map({ $0.readingInMgDl }) + deviceManagerObservable.filteredGlucoseChartData.map({ $0.glucose })
-            let maxReading = readings.max() ?? 300
-            if maxReading > 300 {
-                return 400
-            } else if maxReading > 200 {
-                return 300
-            } else {
-                return 200
-            }
-        }()
-        let maxX = Date()
-        let minX = maxX - 12.hoursToSeconds()
+    var selectedHours: Int
+
+    private var maxY: Int {
+        let readings = deviceManagerObservable.glucoseChartData.map({ $0.readingInMgDl }) + deviceManagerObservable.filteredGlucoseChartData.map({ $0.glucose })
+        let maxReading = readings.max() ?? 300
+        if maxReading > 300 {
+            return 400
+        } else if maxReading > 200 {
+            return 300
+        } else {
+            return 200
+        }
+    }
+
+    private var timeWindow: (min: Date, max: Date) {
+        let max = Date()
+        let min = max - 24.hoursToSeconds()
+        return (min, max)
+    }
+
+    private var strideInHours: Int {
 #if os(watchOS)
-        let strideInHours = 3
+        return 3
 #else
-        let strideInHours = 2
+        return selectedHours > 6 ? 2 : 1
 #endif
-        
+    }
+
+    private func chart(geometry: GeometryProxy) -> some View {
         Chart {
-            AreaMark(x: .value("Time", minX),
+            AreaMark(x: .value("Time", timeWindow.min),
                      yStart: .value("Target range low", 70),
                      yEnd: .value("Target range high", 140))
             .foregroundStyle(.green)
             .opacity(0.25)
-            AreaMark(x: .value("Time", maxX),
+            AreaMark(x: .value("Time", timeWindow.max),
                      yStart: .value("Target range low", 70),
                      yEnd: .value("Target range high", 140))
             .foregroundStyle(.green)
@@ -45,18 +54,19 @@ struct GlucoseChartView: View {
             ForEach(deviceManagerObservable.glucoseChartData, id: \.created) { reading in
                 PointMark(x: .value("Time", reading.created),
                          y: .value("mg/dL", reading.readingInMgDl))
-                    .symbolSize(20)  // Adjust the size of the points
+                    .symbolSize(20)
                     .foregroundStyle(.blue)
             }
             ForEach(deviceManagerObservable.filteredGlucoseChartData, id: \.at) { reading in
                 LineMark(x: .value("Time", reading.at),
                          y: .value("mg/dL", reading.glucose))
-                    .symbolSize(5)  // Adjust the size of the points
+                    .symbolSize(5)
                     .foregroundStyle(.purple)
             }
         }
+        .frame(width: geometry.size.width * CGFloat(24 / selectedHours))
         .chartYScale(domain: 0...maxY)
-        .chartXScale(domain: minX...maxX)
+        .chartXScale(domain: timeWindow.min...timeWindow.max)
         .chartXAxis {
             AxisMarks(values: .stride(by: .hour, count: strideInHours)) { value in
                 AxisValueLabel(format: .dateTime.hour())
@@ -64,12 +74,31 @@ struct GlucoseChartView: View {
                 AxisTick()
             }
         }
+        .padding(.top, 10)
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack {
+                        chart(geometry: geometry)
+                        Color.clear.frame(width: 1, height: 1).id("rightmost")
+                    }
+                }
+                .onAppear {
+                    proxy.scrollTo("rightmost", anchor: .trailing)
+                }
+                .onChange(of: selectedHours) {
+                    proxy.scrollTo("rightmost", anchor: .trailing)
+                }
+            }
+        }
     }
 }
 
-
 struct GlucoseChartView_Previews: PreviewProvider {
     static var previews: some View {
-        GlucoseChartView()
+        GlucoseChartView(selectedHours: 4)
     }
 }

--- a/ios/BioKernel/BioKernel/Views/MainView.swift
+++ b/ios/BioKernel/BioKernel/Views/MainView.swift
@@ -21,6 +21,7 @@ struct MainView: View {
     @State var navigateToSettingsFromUrl = false
     @State var navigateToGlucoseAlerts = false
     @State var settingsFromUrl: CodableSettings? = nil
+    @State var selectedHours = 4
     
     let addButtonRadius = 30.0
     
@@ -30,17 +31,32 @@ struct MainView: View {
                 MainViewSummaryView()
                 MainViewAlertView()
                 Spacer()
-                ZStack(alignment: .bottomTrailing) {
-                    GlucoseChartView()
-                    Button {
-                        navigateToBolus = true
-                    } label: {
-                        Image(systemName: "plus")
+                VStack {
+                    GlucoseChartView(selectedHours: selectedHours)
+                    
+                    HStack {
+                        ForEach([2, 4, 6, 12], id: \.self) { hour in
+                            Button(action: {
+                                selectedHours = hour
+                            }) {
+                                Text("\(hour)h")
+                                    .padding()
+                                    .background(selectedHours == hour ? Color.gray : Color.clear)
+                                    .foregroundColor(selectedHours == hour ? .white : .blue)
+                                    .cornerRadius(8)
+                            }
+                        }
+                        Spacer()
+                        Button {
+                            navigateToBolus = true
+                        } label: {
+                            Image(systemName: "plus")
+                        }
+                        .frame(width: 2 * addButtonRadius, height: 2 * addButtonRadius)
+                        .background(AppColors.primary)
+                        .foregroundColor(.white)
+                        .clipShape(Circle())
                     }
-                    .frame(width: 2 * addButtonRadius, height: 2 * addButtonRadius)
-                    .background(AppColors.primary)
-                    .foregroundColor(.white)
-                    .clipShape(Circle())
                 }
                 .padding()
             }

--- a/ios/BioKernel/BioKernelWatch Watch App/GlucoseChart.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/GlucoseChart.swift
@@ -31,16 +31,15 @@ struct GlucoseChart: View {
 
     private func chart(geometry: GeometryProxy, state: BioKernelState) -> some View {
         Chart {
-            AreaMark(x: .value("Time", timeWindow.start),
-                     yStart: .value("Target range low", 70),
-                     yEnd: .value("Target range high", 140))
+            RectangleMark(
+                xStart: .value("Time", timeWindow.start),
+                xEnd: .value("Time", timeWindow.end),
+                yStart: .value("Target range low", 70),
+                yEnd: .value("Target range high", 140)
+            )
             .foregroundStyle(.green)
             .opacity(0.25)
-            AreaMark(x: .value("Time", timeWindow.end),
-                     yStart: .value("Target range low", 70),
-                     yEnd: .value("Target range high", 140))
-            .foregroundStyle(.green)
-            .opacity(0.25)
+
             ForEach(state.glucoseReadings, id: \.at) { reading in
                 PointMark(
                     x: .value("Time", reading.at),
@@ -50,7 +49,8 @@ struct GlucoseChart: View {
                 .foregroundStyle(.blue)
             }
         }
-        .frame(width: geometry.size.width * CGFloat(24 / selectedHours))
+        // avoid divide by 0
+        .frame(width: geometry.size.width * CGFloat(24 / (selectedHours == 0 ? 4 : selectedHours)))
         .chartYScale(domain: 0...maxY)
         .chartXScale(domain: timeWindow.start...timeWindow.end)
         .chartXVisibleDomain(length: Double(selectedHours).hoursToSeconds())
@@ -80,10 +80,7 @@ struct GlucoseChart: View {
                             selectedHours = timeRanges[nextIndex]
                         }
                     }
-                    .onAppear {
-                        proxy.scrollTo("rightmost", anchor: .trailing)
-                    }
-                    .onChange(of: selectedHours) {
+                    .onChange(of: selectedHours, initial: true) {
                         proxy.scrollTo("rightmost", anchor: .trailing)
                     }
                 }

--- a/ios/BioKernel/BioKernelWatch Watch App/GlucoseChart.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/GlucoseChart.swift
@@ -10,53 +10,84 @@ import Charts
 
 struct GlucoseChart: View {
     @EnvironmentObject var stateViewModel: StateViewModel
-    
+    @State private var selectedHours = 2
+
     private var timeWindow: (start: Date, end: Date) {
         let end = Date()
-        let start = end - 3.hoursToSeconds()
+        let start = end - 24.hoursToSeconds()
         return (start, end)
     }
-    
+
+    private var maxY: Int {
+        let maxReading = stateViewModel.appState?.glucoseReadings.map({ $0.glucoseReadingInMgDl }).max() ?? 200.0
+        if maxReading > 300 {
+            return 400
+        } else if maxReading > 200 {
+            return 300
+        } else {
+            return 200
+        }
+    }
+
+    private func chart(geometry: GeometryProxy, state: BioKernelState) -> some View {
+        Chart {
+            AreaMark(x: .value("Time", timeWindow.start),
+                     yStart: .value("Target range low", 70),
+                     yEnd: .value("Target range high", 140))
+            .foregroundStyle(.green)
+            .opacity(0.25)
+            AreaMark(x: .value("Time", timeWindow.end),
+                     yStart: .value("Target range low", 70),
+                     yEnd: .value("Target range high", 140))
+            .foregroundStyle(.green)
+            .opacity(0.25)
+            ForEach(state.glucoseReadings, id: \.at) { reading in
+                PointMark(
+                    x: .value("Time", reading.at),
+                    y: .value("Glucose", reading.glucoseReadingInMgDl)
+                )
+                .symbolSize(10)
+                .foregroundStyle(.blue)
+            }
+        }
+        .frame(width: geometry.size.width * CGFloat(24 / selectedHours))
+        .chartYScale(domain: 0...maxY)
+        .chartXScale(domain: timeWindow.start...timeWindow.end)
+        .chartXVisibleDomain(length: Double(selectedHours).hoursToSeconds())
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 4)) { value in
+                AxisValueLabel(format: .dateTime.hour())
+            }
+        }
+        .frame(maxHeight: .infinity)
+        .padding(.top, 10)
+    }
+
     var body: some View {
-        let maxY = { () -> Int in
-            let maxReading = stateViewModel.appState?.glucoseReadings.map({ $0.glucoseReadingInMgDl }).max() ?? 200.0
-            if maxReading > 300 {
-                return 400
-            } else if maxReading > 200 {
-                return 300
-            } else {
-                return 200
-            }
-        }()
         if let state = stateViewModel.appState {
-            Chart {
-                AreaMark(x: .value("Time", timeWindow.start),
-                         yStart: .value("Target range low", 70),
-                         yEnd: .value("Target range high", 140))
-                .foregroundStyle(.green)
-                .opacity(0.25)
-                AreaMark(x: .value("Time", timeWindow.end),
-                         yStart: .value("Target range low", 70),
-                         yEnd: .value("Target range high", 140))
-                .foregroundStyle(.green)
-                .opacity(0.25)
-                ForEach(state.glucoseReadings, id: \.at) { reading in
-                    PointMark(
-                        x: .value("Time", reading.at),
-                        y: .value("Glucose", reading.glucoseReadingInMgDl)
-                    )
-                    .symbolSize(10)
-                    .foregroundStyle(.blue)
+            GeometryReader { geometry in
+                ScrollViewReader { proxy in
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack {
+                            chart(geometry: geometry, state: state)
+                            Color.clear.frame(width: 1, height: 1).id("rightmost")
+                        }
+                    }
+                    .onTapGesture {
+                        let timeRanges = [2, 4, 6, 12]
+                        if let currentIndex = timeRanges.firstIndex(of: selectedHours) {
+                            let nextIndex = (currentIndex + 1) % timeRanges.count
+                            selectedHours = timeRanges[nextIndex]
+                        }
+                    }
+                    .onAppear {
+                        proxy.scrollTo("rightmost", anchor: .trailing)
+                    }
+                    .onChange(of: selectedHours) {
+                        proxy.scrollTo("rightmost", anchor: .trailing)
+                    }
                 }
             }
-            .chartYScale(domain: 0...maxY)
-            .chartXScale(domain: timeWindow.start...timeWindow.end)
-            .chartXAxis {
-                AxisMarks(values: .automatic(desiredCount: 4)) { value in
-                    AxisValueLabel(format: .dateTime.hour())
-                }
-            }
-            .frame(maxHeight: .infinity)
         } else {
             Text("No data available")
                 .frame(maxHeight: .infinity)


### PR DESCRIPTION
This PR includes changes to allow the user to select different time ranges to display glucose values for the main glucose chart. It also provides scrolling to see backwards to 24 hours worth of data.

In the iPhone app, there are buttons that people can use to switch. In the Watch app, they click on the chart to change the time range.

It also includes some minor refactoring to improve the readability of the code.