### PR TITLE
Update AI dosing strategy

### DIFF
--- a/ios/BioKernel/BioKernel/Services/MachineLearning.swift
+++ b/ios/BioKernel/BioKernel/Services/MachineLearning.swift
@@ -61,12 +61,11 @@ actor AIDosing: MachineLearning {
     func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date, pidTempBasal: PIDTempBasalResult) async -> Double? {
         
         await log("start")
-        // make sure we have enough data
-        guard let dataFrame = dataFrame else { await log("no frame"); return nil }
+        let dataFrame = dataFrame ?? []
         
         // since this model is just about dosing more, if we have been low at
         // all in the past two hours just bail
-        let min = dataFrame.map({ $0.glucose }).min() ?? 65
+        let min = dataFrame.map({ $0.glucose }).min() ?? 75
         guard min >= 70 else { await log("low in dataFrame, bail"); return nil }
         
         guard let predicted = await getPhysiologicalModels().predictGlucoseIn15Minutes(from: at) else { await log("no predicted glucose"); return nil }
@@ -75,71 +74,21 @@ actor AIDosing: MachineLearning {
         await log("Checking if we're exercising")
         guard await !getWorkoutStatusService().isExercising(at: at) else { await log("is working out"); return nil }
         
-        let digestion = await tempBasalStartingDigestion(settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, insulinOnBoard: insulinOnBoard, dataFrame: dataFrame, at: at, pidTempBasal: pidTempBasal, predicted: predicted)
-        
-        let stuckHigh = await tempBasalStuckHigh(settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, insulinOnBoard: insulinOnBoard, dataFrame: dataFrame, at: at, pidTempBasal: pidTempBasal, predicted: predicted)
-        
-        return digestion ?? stuckHigh
+        return await glucosDynamicISF(settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, insulinOnBoard: insulinOnBoard, dataFrame: dataFrame, at: at, pidTempBasal: pidTempBasal, predicted: predicted)
     }
 
-    func tempBasalStuckHigh(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow], at: Date, pidTempBasal: PIDTempBasalResult, predicted: Double) async -> Double? {
-        let min = dataFrame.map({ $0.glucose }).min() ?? 100
-        let max = dataFrame.map({ $0.glucose }).max() ?? 400
-        
-        // make sure that we're stuck above 220 and that we're not already going down
-        // and that we haven't had large drops already in the last two hours
-        guard glucoseInMgDl >= 220, min >= 220, (max - min) < 100 else { await log("not stuck high, min: \(min), max: \(max)"); return nil }
-        guard predicted >= glucoseInMgDl else { await log("Predict \(String(format: "%0.0f", predicted)) mg/dl vs \(String(format: "%0.0f", glucoseInMgDl)) mg/dl not actionable"); return nil }
-        
-        // this calculation does basic glucose math where it's trying to calculate
-        // a correction that would be needed + IoB from the basal rate, then
-        // adding basalRate * 3 to it to try to kick start the decrease for
-        // a stuck high (basically borrowing basal insulin from the future)
-        let insulinSensitivity = settings.learnedInsulinSensitivity(at: at)
-        let basalRate = settings.learnedBasalRate(at: at)
-        let error = glucoseInMgDl - settings.targetGlucoseInMgDl
-        let insulinType = await getInsulinStorage().currentInsulinType()
-        let basalIoB = PhysiologicalUtilities.calculateBasalBaselineInsulinOnBoard(basalRate: basalRate, insulinType: insulinType)
-        let iobTarget = error / insulinSensitivity + basalIoB + basalRate * 3
-        
-        let insulinNeeded = iobTarget - insulinOnBoard
-        let tempBasal = insulinNeeded  * 1.hoursToSeconds() / settings.correctionDurationInSeconds
-        
-        // if we're going to dose less than the PID controller would, just
-        // bail. The whole point of this model is to dose more than PID would
-        guard tempBasal > pidTempBasal.tempBasal else { await log("Stuck tempBasal <= pidTempBasal: \(String(format: "%0.1f", tempBasal)) <= \(String(format: "%0.1f", pidTempBasal.tempBasal))"); return nil }
-        
-        await log("***Setting stuck tempBasal \(String(format: "%0.1f", tempBasal)) U/h for 30m, pidTempBasal: \(String(format: "%0.1f", pidTempBasal.tempBasal))")
-        
-        return tempBasal
-    }
-    
-    func tempBasalStartingDigestion(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow], at: Date, pidTempBasal: PIDTempBasalResult, predicted: Double) async -> Double? {
+    /// Simplified version of dynamicISF from Trio. Since dynamicISF isn't based on anything
+    /// physiological -- it's just math to dose more when you're high -- let's keep the math super simple.
+    ///
+    /// Conceptually what this is trying to do is get the individual back into a more manageable range
+    /// (below 140) so that the more principled adaptations can take over.
+    func glucosDynamicISF(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow], at: Date, pidTempBasal: PIDTempBasalResult, predicted: Double) async -> Double? {
 
-        // only dose during "waking hours" for now
-        let hour = Calendar.current.component(.hour, from: at)
-        guard hour < 22 && hour >= 7 else { await log ("hour \(hour) outside waking hours"); return nil }
-        
-        await log("Checking if glucose is rising")
-        // make sure that glucose is rising
-        guard predicted >= 180, predicted > glucoseInMgDl else { await log("Predict \(String(format: "%0.0f", predicted)) mg/dl vs \(String(format: "%0.0f", glucoseInMgDl)) mg/dl not actionable"); return nil }
-        
-        await log("Final calcs")
-        // calculate added glucose and dose
-        let insulinSensitivity = settings.learnedInsulinSensitivity(at: at)
-        guard let addedGlucose = dataFrame.addedGlucosePerHour30m(insulinSensitivity: insulinSensitivity) else { await log("can't calc added glucose"); return nil }
-        
-        let aiGain = settings.getMachineLearningGain()
-        let insulinNeeded = aiGain * addedGlucose / insulinSensitivity - insulinOnBoard
-        let tempBasal = insulinNeeded  * 1.hoursToSeconds() / settings.correctionDurationInSeconds
-        
-        // if we're going to dose less than the PID controller would, just
-        // bail. The whole point of this model is to dose more than PID would
-        guard tempBasal > pidTempBasal.tempBasal else { await log("Digestion tempBasal <= pidTempBasal: \(String(format: "%0.1f", tempBasal)) <= \(String(format: "%0.1f", pidTempBasal.tempBasal))"); return nil }
-        
-        await log("***Setting digestion tempBasal \(String(format: "%0.1f", tempBasal)) U/h for 30m, pidTempBasal: \(String(format: "%0.1f", pidTempBasal.tempBasal))")
-        
-        return tempBasal
+        // effectively lowers insulin sensitivity by up to 20% between 140 -> 240
+        // linearly to dose more insulin while high
+        guard glucoseInMgDl >= 140 else { return nil }
+        let scalingFactor = 1 + 0.2 * (glucoseInMgDl - 140) / 100
+        return pidTempBasal.tempBasal * scalingFactor.clamp(low: 1, high: 1.2)
     }
 }
 

--- a/ios/BioKernel/BioKernel/Services/MachineLearning.swift
+++ b/ios/BioKernel/BioKernel/Services/MachineLearning.swift
@@ -74,7 +74,7 @@ actor AIDosing: MachineLearning {
         await log("Checking if we're exercising")
         guard await !getWorkoutStatusService().isExercising(at: at) else { await log("is working out"); return nil }
         
-        return await glucosDynamicISF(settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, insulinOnBoard: insulinOnBoard, dataFrame: dataFrame, at: at, pidTempBasal: pidTempBasal, predicted: predicted)
+        return glucosDynamicISF(glucoseInMgDl: glucoseInMgDl, dataFrame: dataFrame, pidTempBasal: pidTempBasal)
     }
 
     /// Simplified version of dynamicISF from Trio. Since dynamicISF isn't based on anything
@@ -82,7 +82,7 @@ actor AIDosing: MachineLearning {
     ///
     /// Conceptually what this is trying to do is get the individual back into a more manageable range
     /// (below 140) so that the more principled adaptations can take over.
-    func glucosDynamicISF(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow], at: Date, pidTempBasal: PIDTempBasalResult, predicted: Double) async -> Double? {
+    func glucosDynamicISF(glucoseInMgDl: Double, dataFrame: [AddedGlucoseDataRow], pidTempBasal: PIDTempBasalResult) -> Double? {
 
         // effectively lowers insulin sensitivity by up to 20% between 140 -> 240
         // linearly to dose more insulin while high


### PR DESCRIPTION
Removes old AI heuristics and replaces them with a new, simple rule: increase dosing by up to 20% linearly from 140 -> 240 mg/dl. This rule is inspired by DynamicISF from Trio but is significantly simpler.