### PR TITLE
Small fixes to PID, diagnostics, and stop invoking closed loop from the UI

### DIFF
--- a/ios/BioKernel/BioKernel/BioKernelApp.swift
+++ b/ios/BioKernel/BioKernel/BioKernelApp.swift
@@ -48,6 +48,7 @@ class MyAppDelegate: NSObject, UIApplicationDelegate {
         
         print("BACK: registering for remote notifications")
         application.registerForRemoteNotifications()
+        
         return true
     }
     

--- a/ios/BioKernel/BioKernel/LoopKitSupport/DeviceDataManager.swift
+++ b/ios/BioKernel/BioKernel/LoopKitSupport/DeviceDataManager.swift
@@ -390,8 +390,8 @@ class LocalDeviceDataManager: DeviceDataManager {
         await self.processCGMReadingResult(readingResult: result)
     }
     
-    // This method is invoked by either the UI or from a pump BLE heartbeat
-    // so we need to make sure that we wait at least 6 minutes between runs
+// This method is invoked from a pump BLE heartbeat or new CGM data
+// so we need to make sure that we wait at least 4.2 minutes between runs
     func checkCgmDataAndLoop() async {
         let now = currentTime()
         await checkCgmData()

--- a/ios/BioKernel/BioKernel/LoopKitSupport/DeviceDataManager.swift
+++ b/ios/BioKernel/BioKernel/LoopKitSupport/DeviceDataManager.swift
@@ -368,33 +368,33 @@ class LocalDeviceDataManager: DeviceDataManager {
     }
     
     func refreshCgmAndPumpDataFromUI() async {
-        print("checkCgmDataAndLoop call")
-        await checkCgmDataAndLoop()
+        print("checkCgmData call")
+        await checkCgmData()
         
         print("refreshCgmAndPumpDataFromUI")
         guard let pumpManager = self.pumpManager, pumpManager.isOnboarded else {
             return
         }
         
-        // I'm not sure why Loop has this extra call to ensureCurrentPumpData but
-        // since this method comes from the UI it shouldn't happen too often
-        // and should be fine
         print("ensureCurrentPumpData call")
         let _ = await pumpManager.ensureCurrentPumpData()
         print("return")
     }
     
-    // This method is invoked by either the UI or from a pump BLE heartbeat
-    // so we need to make sure that we wait at least 6 minutes between runs
-    func checkCgmDataAndLoop() async {
+    func checkCgmData() async {
         guard let cgmManager = cgmManager else {
             return
         }
-
-        let now = currentTime()
         
         let result = await cgmManager.fetchNewDataIfNeeded()
         await self.processCGMReadingResult(readingResult: result)
+    }
+    
+    // This method is invoked by either the UI or from a pump BLE heartbeat
+    // so we need to make sure that we wait at least 6 minutes between runs
+    func checkCgmDataAndLoop() async {
+        let now = currentTime()
+        await checkCgmData()
         
         // 4.2 minutes comes from Loop, for consistency (they changed it from 6 recently)
         guard now.timeIntervalSince(lastLoopCompleted) > 4.2.minutesToSeconds() else {

--- a/ios/BioKernel/BioKernel/Services/ClosedLoopChartData.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopChartData.swift
@@ -21,6 +21,7 @@ struct ClosedLoopChartData: Identifiable {
     let integratorContribution: Double
     let totalPidContribution: Double
     let deltaGlucoseError: Double
+    let accumulatedError: Double
     let mlInsulin: Double
     let physiologicalInsulin: Double
     let actualInsulin: Double

--- a/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
+++ b/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
@@ -137,11 +137,11 @@ actor LocalPhysiologicalModels: PhysiologicalModels {
         let filteredGlucose = lowPassFilter(glucose: glucoseInMgDl, at: at)
         let error = filteredGlucose - targetGlucoseInMgDl
         var derivative = 0.0
-        if let dt = lastGlucoseAt.map({ at.timeIntervalSince($0) }), dt < 11.minutesToSeconds(), let lastGlucose = lastGlucose {
+        if let dt = lastGlucoseAt.map({ at.timeIntervalSince($0) }), dt < 11.minutesToSeconds(), let lastFilteredGlucose = lastFilteredGlucose {
             // these are slighly non-standard for PID but we do it this
             // way to keep our derivative and integral in glucose units
             // to make it easier to set Ki and Kd
-            derivative = (filteredGlucose - lastGlucose)
+            derivative = (filteredGlucose - lastFilteredGlucose)
             
             // with this check we're trying to only accumulate errors
             // when we're outside of digestion and accumulate deltaGlucose

--- a/ios/BioKernel/BioKernel/ViewModels/DiagnosticViewModel.swift
+++ b/ios/BioKernel/BioKernel/ViewModels/DiagnosticViewModel.swift
@@ -53,6 +53,7 @@ class DiagnosticViewModel: ObservableObject, ClosedLoopChartDataUpdate {
             integratorContribution: integratorContribution,
             totalPidContribution: totalPidContribution,
             deltaGlucoseError: pidResult?.deltaGlucoseError ?? 0,
+            accumulatedError: pidResult?.accumulatedError ?? 0,
             mlInsulin: mlInsulin,
             physiologicalInsulin: physiologicalInsulin,
             actualInsulin: actualInsulin,

--- a/ios/BioKernel/BioKernel/Views/InsulinView.swift
+++ b/ios/BioKernel/BioKernel/Views/InsulinView.swift
@@ -11,7 +11,7 @@ import Charts
 
 struct InsulinView: View {
     @EnvironmentObject var viewModel: DiagnosticViewModel
-    @State private var selectedHours = 2
+    @State private var selectedHours = 4
     
     private var timeWindow: (min: Date, max: Date) {
         let max = Date()

--- a/ios/BioKernel/BioKernel/Views/MLView.swift
+++ b/ios/BioKernel/BioKernel/Views/MLView.swift
@@ -11,7 +11,7 @@ import Charts
 
 struct MLView: View {
     @EnvironmentObject var viewModel: DiagnosticViewModel
-    @State private var selectedHours = 2
+    @State private var selectedHours = 4
     
     private var timeWindow: (min: Date, max: Date) {
         let max = Date()

--- a/ios/BioKernel/BioKernel/Views/PIDView.swift
+++ b/ios/BioKernel/BioKernel/Views/PIDView.swift
@@ -11,7 +11,7 @@ import Charts
 
 struct PIDView: View {
     @EnvironmentObject var viewModel: DiagnosticViewModel
-    @State private var selectedHours = 2
+    @State private var selectedHours = 4
     
     private var timeWindow: (min: Date, max: Date) {
         let max = Date()
@@ -41,6 +41,7 @@ struct PIDView: View {
         var points = [ChartPoint]()
         for data in viewModel.chartData {
             points.append(ChartPoint(at: data.at, value: data.deltaGlucoseError, type: "Delta Glucose Error"))
+            points.append(ChartPoint(at: data.at, value: data.accumulatedError, type: "Accumulated Error"))
         }
         return points
     }


### PR DESCRIPTION
The changes include:
  - Fix PID derivative calculation to use the last filtered value
  - Show accumulated error along with delta glucose error in diagnostics
  - Stop invoking the closed loop algorithm from the UI
  - Change the default time range in diagnostics to 4 hours

Stopping closed loop invocation from the UI is to avoid changing the PID controller's state until there is a heartbeat (either CGM or pump)