### PR TITLE
Basic for diagnostic view charts

### DIFF
--- a/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
+++ b/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		3B7C6D9C2B0C09320030DFA7 /* InsulinStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7C6D9B2B0C09320030DFA7 /* InsulinStorageTests.swift */; };
 		3B7F08412B2DDE33002930A4 /* ClosedLoopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7F08402B2DDE33002930A4 /* ClosedLoopTests.swift */; };
 		3B7F08622B31590D002930A4 /* BolusProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7F08612B31590D002930A4 /* BolusProgressView.swift */; };
+		3B8906552E50EA9500F32799 /* DiagnosticChartScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B8906542E50EA9500F32799 /* DiagnosticChartScrollView.swift */; };
 		3B96F2542D08A2A800ABBA16 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B96F2532D08A2A800ABBA16 /* WidgetKit.framework */; };
 		3B96F2562D08A2A800ABBA16 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B96F2552D08A2A800ABBA16 /* SwiftUI.framework */; };
 		3B96F25F2D08A2A900ABBA16 /* LauncherWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 3B96F2522D08A2A800ABBA16 /* LauncherWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -262,6 +263,7 @@
 		3B7C6D9B2B0C09320030DFA7 /* InsulinStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsulinStorageTests.swift; sourceTree = "<group>"; };
 		3B7F08402B2DDE33002930A4 /* ClosedLoopTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedLoopTests.swift; sourceTree = "<group>"; };
 		3B7F08612B31590D002930A4 /* BolusProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusProgressView.swift; sourceTree = "<group>"; };
+		3B8906542E50EA9500F32799 /* DiagnosticChartScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticChartScrollView.swift; sourceTree = "<group>"; };
 		3B96F2522D08A2A800ABBA16 /* LauncherWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LauncherWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B96F2532D08A2A800ABBA16 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		3B96F2552D08A2A800ABBA16 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
@@ -586,6 +588,7 @@
 				3B7F08612B31590D002930A4 /* BolusProgressView.swift */,
 				3BBC7C7C2B15679700410123 /* BolusView.swift */,
 				3B6063B12B54BDB7009D9CBC /* DecimalPicker.swift */,
+				3B8906542E50EA9500F32799 /* DiagnosticChartScrollView.swift */,
 				3BF1F1E32E4F1D3D00AF36AD /* DiagnosticDataView.swift */,
 				3B6EC2312BD8131A008BFD4D /* DigestionGauge.swift */,
 				3B3C9B112C46B12300BB7CCF /* GlucoseAlertsView.swift */,
@@ -862,6 +865,7 @@
 				3B96F2682D08C86D00ABBA16 /* WatchComms.swift in Sources */,
 				3B96F29A2D08CD6B00ABBA16 /* CommandStatus.swift in Sources */,
 				3B96F29B2D08CD6B00ABBA16 /* SessionDelegator.swift in Sources */,
+				3B8906552E50EA9500F32799 /* DiagnosticChartScrollView.swift in Sources */,
 				3B96F29F2D08CD6B00ABBA16 /* SessionCommands.swift in Sources */,
 				3BD7E2102C48A3AB0093D300 /* NotificationManager.swift in Sources */,
 				3BF1631C2D20A6B700287BA0 /* WorkoutStatusService.swift in Sources */,

--- a/ios/BioKernel/BioKernel/Views/DiagnosticChartScrollView.swift
+++ b/ios/BioKernel/BioKernel/Views/DiagnosticChartScrollView.swift
@@ -1,0 +1,42 @@
+//
+//  DiagnosticChartScrollView.swift
+//  BioKernel
+//
+//  Created by Sam King on 8/16/25.
+//
+
+import SwiftUI
+
+struct DiagnosticChartScrollView<Content: View>: View {
+    @Binding var selectedHours: Int
+    let content: Content
+
+    init(selectedHours: Binding<Int>, @ViewBuilder content: () -> Content) {
+        self._selectedHours = selectedHours
+        self.content = content()
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 0) {
+                        content
+                            .padding()
+                            .frame(width: geometry.size.width * CGFloat(24 / selectedHours))
+                        
+                        Color.clear.frame(width: 0, height: 0).id("scroll_end_anchor")
+                    }
+                }
+                .onAppear {
+                    proxy.scrollTo("scroll_end_anchor", anchor: .trailing)
+                }
+                .onChange(of: selectedHours) { _ in
+                    withAnimation {
+                        proxy.scrollTo("scroll_end_anchor", anchor: .trailing)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ios/BioKernel/BioKernel/Views/DiagnosticChartScrollView.swift
+++ b/ios/BioKernel/BioKernel/Views/DiagnosticChartScrollView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct DiagnosticChartScrollView<Content: View>: View {
     @Binding var selectedHours: Int
     let content: Content
-
+    let scrollAndAnchorId = "scroll_end_anchor"
+    
     init(selectedHours: Binding<Int>, @ViewBuilder content: () -> Content) {
         self._selectedHours = selectedHours
         self.content = content()
@@ -20,20 +21,22 @@ struct DiagnosticChartScrollView<Content: View>: View {
         GeometryReader { geometry in
             ScrollViewReader { proxy in
                 ScrollView(.horizontal, showsIndicators: false) {
+                    // avoid divide by 0
+                    let hours = selectedHours != 0 ? selectedHours : 4
                     HStack(spacing: 0) {
                         content
                             .padding()
-                            .frame(width: geometry.size.width * (selectedHours > 0 ? CGFloat(24 / selectedHours) : 1.0))
+                            .frame(width: geometry.size.width * CGFloat(24 / hours))
                         
-                        Color.clear.frame(width: 0, height: 0).id("scroll_end_anchor")
+                        Color.clear.frame(width: 0, height: 0).id(scrollAndAnchorId)
                     }
                 }
                 .onAppear {
-                    proxy.scrollTo("scroll_end_anchor", anchor: .trailing)
+                    proxy.scrollTo(scrollAndAnchorId, anchor: .trailing)
                 }
                 .onChange(of: selectedHours) { _ in
                     withAnimation {
-                        proxy.scrollTo("scroll_end_anchor", anchor: .trailing)
+                        proxy.scrollTo(scrollAndAnchorId, anchor: .trailing)
                     }
                 }
             }

--- a/ios/BioKernel/BioKernel/Views/DiagnosticChartScrollView.swift
+++ b/ios/BioKernel/BioKernel/Views/DiagnosticChartScrollView.swift
@@ -23,7 +23,7 @@ struct DiagnosticChartScrollView<Content: View>: View {
                     HStack(spacing: 0) {
                         content
                             .padding()
-                            .frame(width: geometry.size.width * CGFloat(24 / selectedHours))
+                            .frame(width: geometry.size.width * (selectedHours > 0 ? CGFloat(24 / selectedHours) : 1.0))
                         
                         Color.clear.frame(width: 0, height: 0).id("scroll_end_anchor")
                     }

--- a/ios/BioKernel/BioKernel/Views/InsulinView.swift
+++ b/ios/BioKernel/BioKernel/Views/InsulinView.swift
@@ -69,6 +69,9 @@ struct InsulinView: View {
                     .chartForegroundStyleScale(["Glucose": .blue])
                     .chartXScale(domain: timeWindow.min...timeWindow.max)
                     .chartLegend(position: .bottom, alignment: .trailing)
+                    .chartYAxis {
+                        AxisMarks(preset: .inset, position: .trailing)
+                    }
                     
                     Chart(iobChartPoints) {
                         LineMark(
@@ -81,6 +84,9 @@ struct InsulinView: View {
                     .chartForegroundStyleScale(["IOB": .red, "Basal Rate IOB": .green])
                     .chartXScale(domain: timeWindow.min...timeWindow.max)
                     .chartLegend(position: .bottom, alignment: .trailing)
+                    .chartYAxis {
+                        AxisMarks(preset: .inset, position: .trailing)
+                    }
                 }
                 .chartXAxis {
                     AxisMarks(values: .stride(by: .hour, count: strideInHours)) { value in

--- a/ios/BioKernel/BioKernel/Views/InsulinView.swift
+++ b/ios/BioKernel/BioKernel/Views/InsulinView.swift
@@ -15,7 +15,7 @@ struct InsulinView: View {
     
     private var timeWindow: (min: Date, max: Date) {
         let max = Date()
-        let min = max - TimeInterval(selectedHours * 3600)
+        let min = max - TimeInterval(24 * 3600)
         return (min, max)
     }
     
@@ -42,6 +42,10 @@ struct InsulinView: View {
         }
         return points
     }
+
+    private var strideInHours: Int {
+        return selectedHours > 6 ? 2 : 1
+    }
     
     var body: some View {
         VStack {
@@ -53,30 +57,39 @@ struct InsulinView: View {
             }
             .pickerStyle(SegmentedPickerStyle())
             
-            VStack {
-                Chart(glucoseChartPoints) {
-                    LineMark(
-                        x: .value("Time", $0.at),
-                        y: .value("Value", $0.value)
-                    )
-                    .foregroundStyle(by: .value("Series", $0.type))
+            DiagnosticChartScrollView(selectedHours: $selectedHours) {
+                VStack {
+                    Chart(glucoseChartPoints) {
+                        LineMark(
+                            x: .value("Time", $0.at),
+                            y: .value("Value", $0.value)
+                        )
+                        .foregroundStyle(by: .value("Series", $0.type))
+                    }
+                    .chartForegroundStyleScale(["Glucose": .blue])
+                    .chartXScale(domain: timeWindow.min...timeWindow.max)
+                    .chartLegend(position: .bottom, alignment: .trailing)
+                    
+                    Chart(iobChartPoints) {
+                        LineMark(
+                            x: .value("Time", $0.at),
+                            y: .value("Value", $0.value)
+                        )
+                        .foregroundStyle(by: .value("Series", $0.type))
+                        .lineStyle(StrokeStyle(dash: $0.type == "Basal Rate IOB" ? [5, 5] : []))
+                    }
+                    .chartForegroundStyleScale(["IOB": .red, "Basal Rate IOB": .green])
+                    .chartXScale(domain: timeWindow.min...timeWindow.max)
+                    .chartLegend(position: .bottom, alignment: .trailing)
                 }
-                .chartForegroundStyleScale(["Glucose": .blue])
-                .chartXScale(domain: timeWindow.min...timeWindow.max)
-                .chartLegend(position: .bottom, alignment: .leading)
-                
-                Chart(iobChartPoints) {
-                    LineMark(
-                        x: .value("Time", $0.at),
-                        y: .value("Value", $0.value)
-                    )
-                    .foregroundStyle(by: .value("Series", $0.type))
-                    .lineStyle(StrokeStyle(dash: $0.type == "Basal Rate IOB" ? [5, 5] : []))
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .hour, count: strideInHours)) { value in
+                        AxisValueLabel(format: .dateTime.hour())
+                        AxisGridLine()
+                        AxisTick()
+                    }
                 }
-                .chartForegroundStyleScale(["IOB": .red, "Basal Rate IOB": .green])
-                .chartXScale(domain: timeWindow.min...timeWindow.max)
-                .chartLegend(position: .bottom, alignment: .leading)
-            }.padding()
+            }
         }
     }
 }

--- a/ios/BioKernel/BioKernel/Views/MLView.swift
+++ b/ios/BioKernel/BioKernel/Views/MLView.swift
@@ -70,6 +70,9 @@ struct MLView: View {
                     }
                     .chartXScale(domain: timeWindow.min...timeWindow.max)
                     .chartLegend(position: .bottom, alignment: .trailing)
+                    .chartYAxis {
+                        AxisMarks(preset: .inset, position: .trailing)
+                    }
                     
                     Chart(mlInsulinLastThreeHoursChartPoints) {
                         LineMark(
@@ -82,6 +85,9 @@ struct MLView: View {
                     .chartForegroundStyleScale(["ML Insulin Last 3 Hours": .purple, "Basal Rate * 3": .green])
                     .chartXScale(domain: timeWindow.min...timeWindow.max)
                     .chartLegend(position: .bottom, alignment: .trailing)
+                    .chartYAxis {
+                        AxisMarks(preset: .inset, position: .trailing)
+                    }
                 }
                 .chartXAxis {
                     AxisMarks(values: .stride(by: .hour, count: strideInHours)) { value in

--- a/ios/BioKernel/BioKernel/Views/PIDView.swift
+++ b/ios/BioKernel/BioKernel/Views/PIDView.swift
@@ -71,6 +71,9 @@ struct PIDView: View {
                     }
                     .chartXScale(domain: timeWindow.min...timeWindow.max)
                     .chartLegend(position: .bottom, alignment: .trailing)
+                    .chartYAxis {
+                        AxisMarks(preset: .inset, position: .trailing)
+                    }
                     
                     Chart(deltaGlucoseChartPoints) {
                         LineMark(
@@ -81,6 +84,9 @@ struct PIDView: View {
                     }
                     .chartXScale(domain: timeWindow.min...timeWindow.max)
                     .chartLegend(position: .bottom, alignment: .trailing)
+                    .chartYAxis {
+                        AxisMarks(preset: .inset, position: .trailing)
+                    }
                 }
                 .chartXAxis {
                     AxisMarks(values: .stride(by: .hour, count: strideInHours)) { value in


### PR DESCRIPTION
This PR adds basic scrolling capabilities to the charts we display in our diagnostic view. It largely matches the logic for scrolling with the GlucoseChartView and consolidates some of the repeated code into a new class: DiagnosticChartScrollView.