### PR TITLE
Don't allow the loop to run twice in a row

### DIFF
--- a/ios/BioKernel/BioKernel/LoopKitSupport/DeviceDataManager.swift
+++ b/ios/BioKernel/BioKernel/LoopKitSupport/DeviceDataManager.swift
@@ -363,7 +363,6 @@ class LocalDeviceDataManager: DeviceDataManager {
     // MARK: - core looping functions
     func newCgmDataAvailable(readingResult: CGMReadingResult) async {
         let now = currentTime()
-        print("PID: processCGMReadingResult...")
         await processCGMReadingResult(readingResult: readingResult)
         await self.checkPumpDataAndLoop(now: now)
     }
@@ -410,7 +409,6 @@ class LocalDeviceDataManager: DeviceDataManager {
         }
 
         // 4.2 minutes comes from Loop, for consistency (they changed it from 6 recently)
-        print("Lastloop \(lastLoopCompleted) -> now \(now)")
         guard now.timeIntervalSince(lastLoopCompleted) > 4.2.minutesToSeconds() else {
             print("wait for enough time to elapse before running again")
             return
@@ -434,10 +432,6 @@ class LocalDeviceDataManager: DeviceDataManager {
         switch readingResult {
         case .newData(let values):
             log.default("CGMManager: did update with %d values", values.count)
-            print("PID CGM:")
-            for value in values {
-                print("  - PID \(value.date) \(value.quantity.doubleValue(for: .milligramsPerDeciliter))")
-            }
             
             await getGlucoseStorage().addCgmEvents(glucoseReadings: values)
             let lastReading = await getGlucoseStorage().lastReading()

--- a/ios/BioKernel/BioKernel/Services/GlucoseStorage.swift
+++ b/ios/BioKernel/BioKernel/Services/GlucoseStorage.swift
@@ -55,6 +55,12 @@ actor LocalGlucoseStorage: GlucoseStorage {
     }
     
     func addCgmEvents(glucoseReadings: [NewGlucoseSample]) async {
+        let syncIdentifiers = Set(self.glucoseReadings.map { $0.syncIdentifier })
+        let glucoseReadings = glucoseReadings.filter { !syncIdentifiers.contains($0.syncIdentifier) }
+        guard !glucoseReadings.isEmpty else {
+            return
+        }
+        
         await replayLogger.add(events: glucoseReadings)
         self.glucoseReadings.append(contentsOf: glucoseReadings)
         self.glucoseReadings = self.glucoseReadings.sorted { $0.date < $1.date }


### PR DESCRIPTION
Adds logic to the core closed loop service to ensure that only one closed loop algorithm invocation can run at any given time.