### PR TITLE
Loosen restriction on micro bolus

### DIFF
--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -94,12 +94,6 @@ actor LocalClosedLoopService: ClosedLoopService {
         let glucoseThreshold = targetGlucoseInMgDl + 20
         guard glucoseInMgDl >= glucoseThreshold else { return nil }
         
-        // make sure that our glucose is rising or close to flat. The
-        // reason that we want to allow flat glucose is that sometimes
-        // the sensor can get saturated at 400 mg/dl, and we want
-        // to micro bolus in this case
-        guard predictedGlucoseInMgDl > (glucoseInMgDl - 2) else { return nil }
-        
         // convert the temp basal to the amount of insulin the closed loop algorithm
         // decided to deliver, subtracting off the basal rate so that we're
         // only delivering the correction
@@ -114,7 +108,6 @@ actor LocalClosedLoopService: ClosedLoopService {
         // convert the temp basal to the amount of insulin the closed loop algorithm
         // decided to deliver, subtracting off the basal rate so that we're
         // only delivering the correction
-        
         let insulin = (tempBasal - basalRate) * correctionDurationHours
         guard insulin > 0 else { return nil } // Ensure insulin amount is positive
     

--- a/ios/BioKernel/BioKernelTests/MicroBolusAmountTest.swift
+++ b/ios/BioKernel/BioKernelTests/MicroBolusAmountTest.swift
@@ -90,20 +90,6 @@ final class MicroBolusTests: XCTestCase {
         XCTAssertNil(amount, "Should not issue micro bolus when glucose is less than 20 mg/dL above target")
     }
     
-    @MainActor func testNoMicroBolusWhenGlucoseFalling() async throws {
-        let amount = await closedLoop.microBolusAmount(
-            tempBasal: 2.0,
-            settings: settings.snapshot(),
-            glucoseInMgDl: 150,
-            targetGlucoseInMgDl: 100,
-            basalRate: 1.0,
-            predictedGlucoseInMgDl: 145, // Predicted < current - 2
-            at: Date()
-        )
-        
-        XCTAssertNil(amount, "Should not issue micro bolus when glucose is predicted to fall")
-    }
-    
     @MainActor func testNoMicroBolusWhenInsulinAmountNegative() async throws {
         let amount = await closedLoop.microBolusAmount(
             tempBasal: 0.5, // Less than basal rate


### PR DESCRIPTION
This commit removes the constraint that disables micro bolus when glucose is going down. Since we want to use a micro bolus to deliver insulin faster we should use it any time the algorithm decides to dose even if glucose is falling.

This change will help lower glucose faster overnight.