### PR TITLE
Include basal insulin with micro bolus amount

### DIFF
--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -115,7 +115,7 @@ actor LocalClosedLoopService: ClosedLoopService {
         let maxBolus = settings.maxBasalRateUnitsPerHour * correctionDurationHours
         
         // Deliver part for now so that if nothing changes we deliver the full amount over 15-30 minutes
-        let amount = (settings.getMicroBolusDoseFactor() * insulin).clamp(low: 0, high: insulin)
+        let amount = (settings.getMicroBolusDoseFactor() * insulin).clamp(low: 0, high: min(insulin, maxBolus))
     
         // Round to the nearest supported bolus volume
         return await getDeviceDataManager().pumpManager?.roundToSupportedBolusVolume(units: amount) ?? amount

--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -86,7 +86,7 @@ actor LocalClosedLoopService: ClosedLoopService {
         return lastRun.action == .setTempBasal
     }
     
-    func microBolusAmount(tempBasal: Double, settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, basalRate: Double, at: Date) async -> Double? {
+    func microBolusAmount(tempBasal: Double, settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, at: Date) async -> Double? {
         // make sure that we haven't issued a micro bolus in the last 4.2 minutes
         guard lastMicroBolus.map({ Date().timeIntervalSince($0) > 4.2.minutesToSeconds() }) ?? true else { return nil }
 
@@ -243,8 +243,8 @@ actor LocalClosedLoopService: ClosedLoopService {
         // calculate the micro bolus candidates and the biological invariant
         // IMPORTANT: you must run the mlTempBasal through the safety logic and use only
         // that temp basal for micro bolus calculations, or you can use the physiological temp basal
-        let microBolusSafety = await microBolusAmount(tempBasal: safetyTempBasal, settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, basalRate: basalRate, at: at) ?? 0.0
-        let microBolusPhysiological = await microBolusAmount(tempBasal: physiologicalTempBasal, settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, basalRate: basalRate, at: at) ?? 0.0
+        let microBolusSafety = await microBolusAmount(tempBasal: safetyTempBasal, settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, at: at) ?? 0.0
+        let microBolusPhysiological = await microBolusAmount(tempBasal: physiologicalTempBasal, settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, at: at) ?? 0.0
         let biologicalInvariant = await getPhysiologicalModels().deltaGlucoseError(settings: settings, dataFrame: dataFrame, at: at)
         
         let dose = determineDose(settings: settings, physiologicalTempBasal: physiologicalTempBasal, mlTempBasal: mlTempBasal, safetyTempBasal: safetyTempBasal, microBolusPhysiological: microBolusPhysiological, microBolusSafety: microBolusSafety, biologicalInvariant: biologicalInvariant, isExercising: isExercising, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)

--- a/ios/BioKernel/BioKernelTests/MicroBolusAmountTest.swift
+++ b/ios/BioKernel/BioKernelTests/MicroBolusAmountTest.swift
@@ -89,7 +89,7 @@ final class MicroBolusTests: XCTestCase {
     
     @MainActor func testNoMicroBolusWhenInsulinAmountNegative() async throws {
         let amount = await closedLoop.microBolusAmount(
-            tempBasal: 0.5, // Less than basal rate
+            tempBasal: -0.5,
             settings: settings.snapshot(),
             glucoseInMgDl: 150,
             targetGlucoseInMgDl: 100,


### PR DESCRIPTION
Previously we only included the correction, or the amount of insulin above the current basal rate, for micro bolus amounts. This commit updates the logic to make available all of the insulin that the algorithm decided to dose at this time step.