### PR TITLE
Fix SIGILL crash in Xcode Cloud unit tests

### DIFF
--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -36,6 +36,8 @@ actor LocalClosedLoopService: ClosedLoopService {
     
     init() {
         closedLoopResults = (try? storage.read()) ?? []
+        // avoid creating a background task when testing
+        guard !isRunningTests else { return }
         Task { await updateFilteredGlucoseChartData() }
     }
     

--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -34,11 +34,11 @@ actor LocalClosedLoopService: ClosedLoopService {
     var isRunningLoop = false
     weak var delegate: (any ClosedLoopChartDataUpdate)? = nil
     
-    init() {
+    init(startBackgroundTask: Bool = true) {
         closedLoopResults = (try? storage.read()) ?? []
-        // avoid creating a background task when testing
-        guard !isRunningTests else { return }
-        Task { await updateFilteredGlucoseChartData() }
+        if startBackgroundTask {
+            Task { await updateFilteredGlucoseChartData() }
+        }
     }
     
     func updateFilteredGlucoseChartData() async {

--- a/ios/BioKernel/BioKernel/Services/GlucoseStorage.swift
+++ b/ios/BioKernel/BioKernel/Services/GlucoseStorage.swift
@@ -28,6 +28,8 @@ actor LocalGlucoseStorage: GlucoseStorage {
     
     init() {
         glucoseReadings = (try? storage.read()) ?? []
+        // avoid creating a background task when testing
+        guard !isRunningTests else { return }
         Task { await updateGlucoseChartData() }
     }
     

--- a/ios/BioKernel/BioKernel/Services/GlucoseStorage.swift
+++ b/ios/BioKernel/BioKernel/Services/GlucoseStorage.swift
@@ -26,11 +26,11 @@ actor LocalGlucoseStorage: GlucoseStorage {
     var storage = getStoredObject().create(fileName: "glucose.json")
     let replayLogger = getEventLogger()
     
-    init() {
+    init(startBackgroundTask: Bool = true) {
         glucoseReadings = (try? storage.read()) ?? []
-        // avoid creating a background task when testing
-        guard !isRunningTests else { return }
-        Task { await updateGlucoseChartData() }
+        if startBackgroundTask {
+            Task { await updateGlucoseChartData() }
+        }
     }
     
     func lastReading() async -> NewGlucoseSample? {

--- a/ios/BioKernel/BioKernelTests/ClosedLoopSafetyTests.swift
+++ b/ios/BioKernel/BioKernelTests/ClosedLoopSafetyTests.swift
@@ -32,7 +32,7 @@ final class ClosedLoopSafetyTests: XCTestCase {
     // MARK: - Max Basal Safety Tests
     
     func testMaxBasalSafetyLimits() async throws {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         let maxBasal = 2.0
         await settings.update(maxBasalRateUnitsPerHour: maxBasal)
@@ -70,7 +70,7 @@ final class ClosedLoopSafetyTests: XCTestCase {
     
     // MARK: - Stale Data Tests
     func testStaleCGMData() async throws {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         let freshnessInterval = 10.minutesToSeconds()
         await settings.update(freshnessIntervalInSeconds: freshnessInterval)
@@ -94,7 +94,7 @@ final class ClosedLoopSafetyTests: XCTestCase {
     
     // MARK: - Recovery Tests
     func testRecoveryFromSafetyViolations() async throws {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         await settings.update(useBiologicalInvariant: true)
         
@@ -173,7 +173,7 @@ final class ClosedLoopSafetyTests: XCTestCase {
     }
     
     @MainActor func testNegativeBasalRateClampedToZero() async throws {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = MockSettingsStorage()
         
         let result = await closedLoop.applyGuardrails(
@@ -188,7 +188,7 @@ final class ClosedLoopSafetyTests: XCTestCase {
     }
 
     @MainActor func testShutOffBasalRateWhenCurrentGlucoseBelowThreshold() async throws {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = MockSettingsStorage()
         settings.update(shutOffGlucoseInMgDl: 80.0)
         
@@ -204,7 +204,7 @@ final class ClosedLoopSafetyTests: XCTestCase {
     }
 
     @MainActor func testShutOffBasalRateWhenPredictedGlucoseBelowThreshold() async throws {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = MockSettingsStorage()
         settings.update(shutOffGlucoseInMgDl: 80.0)
         
@@ -221,7 +221,7 @@ final class ClosedLoopSafetyTests: XCTestCase {
     
     // MARK: - Tests for bugs we've found
     @MainActor func testDetermineDoseActualTempBasalMatchesSelectedTempBasal() async throws {
-            let closedLoop = LocalClosedLoopService()
+            let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
             let settings = MockSettingsStorage()
             settings.update(useMicroBolus: false, useMachineLearningClosedLoop: false, useBiologicalInvariant: false)
             

--- a/ios/BioKernel/BioKernelTests/ClosedLoopTests.swift
+++ b/ios/BioKernel/BioKernelTests/ClosedLoopTests.swift
@@ -51,7 +51,7 @@ final class ClosedLoopTests: XCTestCase {
     }
     
     func testDoseLogic() async {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: false, useMachineLearningClosedLoop: false, useBiologicalInvariant: false)
         
@@ -65,7 +65,7 @@ final class ClosedLoopTests: XCTestCase {
     }
     
     func testDoseLogicUseMachineLearning() async {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: false, useMachineLearningClosedLoop: true, useBiologicalInvariant: false)
         
@@ -79,7 +79,7 @@ final class ClosedLoopTests: XCTestCase {
     }
     
     func testDoseLogicUseMachineLearningMicroBolus() async {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: true, useMachineLearningClosedLoop: true, useBiologicalInvariant: false)
         
@@ -93,7 +93,7 @@ final class ClosedLoopTests: XCTestCase {
     }
     
     func testDoseLogicUseMicroBolus() async {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: true, useMachineLearningClosedLoop: false, useBiologicalInvariant: false)
         
@@ -112,7 +112,7 @@ final class ClosedLoopTests: XCTestCase {
     }
     
     func testDoseLogicDisableMicroBolusFromExercise() async {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: true, useMachineLearningClosedLoop: false, useBiologicalInvariant: false)
         
@@ -127,7 +127,7 @@ final class ClosedLoopTests: XCTestCase {
     
     
     func testDoseLogicUseBiologicalInvariant() async {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: false, useMachineLearningClosedLoop: false, useBiologicalInvariant: true)
         
@@ -151,7 +151,7 @@ final class ClosedLoopTests: XCTestCase {
     }
     
     func testDoseLogicUseMicroBolusBiologicalInvariant() async {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: true, useMachineLearningClosedLoop: false, useBiologicalInvariant: true)
         
@@ -175,7 +175,7 @@ final class ClosedLoopTests: XCTestCase {
     }
     
     func testDoseLogicUseMachineLearningBiologicalInvariant() async {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: false, useMachineLearningClosedLoop: true, useBiologicalInvariant: true)
         
@@ -199,7 +199,7 @@ final class ClosedLoopTests: XCTestCase {
     }
     
     func testDoseLogicUseAll() async {
-        let closedLoop = LocalClosedLoopService()
+        let closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: true, useMachineLearningClosedLoop: true, useBiologicalInvariant: true)
         

--- a/ios/BioKernel/BioKernelTests/LoopFunctionTests.swift
+++ b/ios/BioKernel/BioKernelTests/LoopFunctionTests.swift
@@ -51,7 +51,7 @@ final class LoopFunctionTests: XCTestCase {
         Dependency.mock { MockSafetyService() as SafetyService }
         Dependency.mock { MockStoredObject() as StoredObject }
         
-        closedLoop = LocalClosedLoopService()
+        closedLoop = LocalClosedLoopService(startBackgroundTask: false)
     }
     
     override func tearDownWithError() throws {

--- a/ios/BioKernel/BioKernelTests/MicroBolusAmountTest.swift
+++ b/ios/BioKernel/BioKernelTests/MicroBolusAmountTest.swift
@@ -24,7 +24,7 @@ final class MicroBolusTests: XCTestCase {
         Dependency.mock { MockWatchComms() as WatchComms }
         Dependency.mock { MockDeviceDataManager() as DeviceDataManager }
         
-        closedLoop = LocalClosedLoopService()
+        closedLoop = LocalClosedLoopService(startBackgroundTask: false)
         
         // Set default test values
         settings.update(


### PR DESCRIPTION
Skip background Tasks in LocalClosedLoopService and LocalGlucoseStorage
init when running tests. These unstructured Tasks could outlive test
teardown, resolve dependencies after mocks were reset, and trigger
production initialization that crashes in the CI environment.
