### PR TITLE
First cut refactor of closed loop structures

### DIFF
--- a/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
+++ b/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		3B4CFE222C223DD900BDB1CB /* ShareClientUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B7C6D942B083A4C0030DFA7 /* ShareClientUI.framework */; };
 		3B4CFE232C223DD900BDB1CB /* ShareClientUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B7C6D942B083A4C0030DFA7 /* ShareClientUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3B5076392F92F77400E5D3A6 /* PushNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5076382F92F77400E5D3A6 /* PushNotificationService.swift */; };
+		3B50774C2F93DAB800E5D3A6 /* DosingDecisionTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B50774B2F93DAB800E5D3A6 /* DosingDecisionTestHelpers.swift */; };
 		3B5329502B5D8451000DED1A /* AddedGlucoseDataFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B53294F2B5D8451000DED1A /* AddedGlucoseDataFrame.swift */; };
 		3B6063B02B54BDA9009D9CBC /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6063AF2B54BDA9009D9CBC /* SettingsViewModel.swift */; };
 		3B6063B22B54BDB7009D9CBC /* DecimalPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6063B12B54BDB7009D9CBC /* DecimalPicker.swift */; };
@@ -235,6 +236,7 @@
 		3B4CFE132C2230D800BDB1CB /* CGMBLEKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CGMBLEKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4CFE162C2230DF00BDB1CB /* CGMBLEKitUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CGMBLEKitUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B5076382F92F77400E5D3A6 /* PushNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationService.swift; sourceTree = "<group>"; };
+		3B50774B2F93DAB800E5D3A6 /* DosingDecisionTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DosingDecisionTestHelpers.swift; sourceTree = "<group>"; };
 		3B53294F2B5D8451000DED1A /* AddedGlucoseDataFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddedGlucoseDataFrame.swift; sourceTree = "<group>"; };
 		3B6063AF2B54BDA9009D9CBC /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		3B6063B12B54BDB7009D9CBC /* DecimalPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecimalPicker.swift; sourceTree = "<group>"; };
@@ -616,6 +618,7 @@
 			isa = PBXGroup;
 			children = (
 				3BEE4E1F2B5FF4A000A09203 /* DateTime.swift */,
+				3B50774B2F93DAB800E5D3A6 /* DosingDecisionTestHelpers.swift */,
 				3CAAFC8F2B0D73C400597055 /* MockClasses.swift */,
 				3CAAFC8B2B0D71AE00597055 /* ReplayLogs.swift */,
 			);
@@ -930,6 +933,7 @@
 				3CAAFC8C2B0D71AE00597055 /* ReplayLogs.swift in Sources */,
 				3B40DE692D24453F0032328F /* LoopFunctionTests.swift in Sources */,
 				3B7F08412B2DDE33002930A4 /* ClosedLoopTests.swift in Sources */,
+				3B50774C2F93DAB800E5D3A6 /* DosingDecisionTestHelpers.swift in Sources */,
 				3CAAFC902B0D73C400597055 /* MockClasses.swift in Sources */,
 				3BA00A572D231CA00002B051 /* ClosedLoopSafetyTests.swift in Sources */,
 				3B348DAE2B5DAFB0000A40E9 /* SafetyServiceTests.swift in Sources */,

--- a/ios/BioKernel/BioKernel/DataTypes/ClosedLoopDataTypes.swift
+++ b/ios/BioKernel/BioKernel/DataTypes/ClosedLoopDataTypes.swift
@@ -7,13 +7,38 @@
 
 import Foundation
 
-public enum ClosedLoopAction: String, Codable {
-    case setTempBasal
+public enum DosingDecision: Codable, Equatable {
+    case tempBasal(unitsPerHour: Double)
+    case microBolus(units: Double)
+    case suspendForBiologicalInvariant(mgDlPerHour: Double)
+}
+
+public enum SkipReason: String, Codable {
     case openLoop
     case glucoseReadingStale
     case pumpReadingStale
     case noPumpManager
-    case pumpError
+}
+
+public enum LoopOutcome: Codable {
+    case skipped(SkipReason)
+    case dosed(LoopSnapshot)
+    case pumpError(attempted: LoopSnapshot)
+}
+
+public extension LoopOutcome {
+    var skipReason: SkipReason? {
+        if case .skipped(let reason) = self { return reason }
+        return nil
+    }
+
+    var snapshot: LoopSnapshot? {
+        switch self {
+        case .dosed(let snapshot): return snapshot
+        case .pumpError(let snapshot): return snapshot
+        case .skipped: return nil
+        }
+    }
 }
 
 public struct SafetyResult: Codable {
@@ -26,95 +51,51 @@ public struct SafetyResult: Codable {
     let machineLearningInsulinLastThreeHours: Double
     let biologicalInvariantMgDlPerHour: Double?
     let biologicalInvariantViolation: Bool
-    
-    static func withTempBasal(machineLearningTempBasal: Double, physiologicalTempBasal: Double, actualTempBasal: Double, machineLearningInsulinLastThreeHours: Double, biologicalInvariantMgDlPerHour: Double?) -> SafetyResult {
-        
-        return SafetyResult(machineLearningTempBasal: machineLearningTempBasal, physiologicalTempBasal: physiologicalTempBasal, actualTempBasal: actualTempBasal, machineLearningMicroBolus: 0.0, physiologicalMicroBolus: 0.0, actualMicroBolus: 0.0, machineLearningInsulinLastThreeHours: machineLearningInsulinLastThreeHours, biologicalInvariantMgDlPerHour: biologicalInvariantMgDlPerHour, biologicalInvariantViolation: false)
-    }
-    
-    static func withMicroBolus(machineLearningMicroBolus: Double, physiologicalMicroBolus: Double, actualMicroBolus: Double, machineLearningInsulinLastThreeHours: Double, biologicalInvariantMgDlPerHour: Double?) -> SafetyResult {
+}
 
-        return SafetyResult(machineLearningTempBasal: 0.0, physiologicalTempBasal: 0.0, actualTempBasal: 0.0, machineLearningMicroBolus: machineLearningMicroBolus, physiologicalMicroBolus: physiologicalMicroBolus, actualMicroBolus: actualMicroBolus, machineLearningInsulinLastThreeHours: machineLearningInsulinLastThreeHours, biologicalInvariantMgDlPerHour: biologicalInvariantMgDlPerHour, biologicalInvariantViolation: false)
-    }
-    
-    static func withBiologicalInvariantViolation(biologicalInvariantMgDlPerHour: Double, machineLearningInsulinLastThreeHours: Double) -> SafetyResult {
-        return SafetyResult(machineLearningTempBasal: 0, physiologicalTempBasal: 0, actualTempBasal: 0, machineLearningMicroBolus: 0, physiologicalMicroBolus: 0, actualMicroBolus: 0, machineLearningInsulinLastThreeHours: machineLearningInsulinLastThreeHours, biologicalInvariantMgDlPerHour: biologicalInvariantMgDlPerHour, biologicalInvariantViolation: true)
-    }
+public struct LoopSnapshot: Codable {
+    let glucoseInMgDl: Double
+    let predictedGlucoseInMgDl: Double
+    let insulinOnBoard: Double
+    let targetGlucoseInMgDl: Double
+    let insulinSensitivity: Double
+    let basalRate: Double
+
+    let decision: DosingDecision
+    let safetyResult: SafetyResult
+    let pidTempBasalResult: PIDTempBasalResult
+
+    let mlDurationInSeconds: TimeInterval
+    let safetyDurationInSeconds: TimeInterval
+    let proportionalControllerDurationInSeconds: TimeInterval
+
+    let predictedAddedGlucoseInMgDlPerHour: Double
 }
 
 public struct ClosedLoopResult: Codable {
-    let at: Date
-    let action: ClosedLoopAction
-    let settings: CodableSettings
-    let glucoseInMgDl: Double?
-    let predictedGlucoseInMgDl: Double?
-    let insulinOnBoard: Double?
-    let insulinSensitivity: Double?
-    let basalRate: Double?
-    let tempBasal: Double?
-    let shadowTempBasal: Double?
-    let shadowPredictedAddedGlucose: Double?
-    let shadowMlAddedGlucose: Double?
-    let shadowAddedGlucoseDataFrame: [AddedGlucoseDataRow]?
-    let safetyResult: SafetyResult?
-    let durationInSeconds: TimeInterval
-    let mlDurationInSeconds: TimeInterval
-    let safetyDurationInSeconds: TimeInterval
-    let proportionalControllerDurationInSeconds: TimeInterval
-    let microBolusAmount: Double?
-    let cgmPumpMetadata: CgmPumpMetadata
-    let pidTempBasalResult: PIDTempBasalResult?
-    let targetGlucoseInMgDl: Double?
-    
-    init(at: Date, action: ClosedLoopAction, settings: CodableSettings, glucoseInMgDl: Double?, predictedGlucoseInMgDl: Double?, insulinOnBoard: Double?, insulinSensitivity: Double?, basalRate: Double?, tempBasal: Double?, shadowTempBasal: Double?, shadowPredictedAddedGlucose: Double?, shadowMlAddedGlucose: Double?, shadowAddedGlucoseDataFrame: [AddedGlucoseDataRow]?, safetyResult: SafetyResult?, mlDuration: TimeInterval, safetyDuration: TimeInterval, proportionalControllerDuration: TimeInterval, microBolusAmount: Double?, cgmPumpMetadata: CgmPumpMetadata, pidTempBasalResult: PIDTempBasalResult?, targetGlucoseInMgDl: Double?) {
-        self.at = at
-        self.action = action
-        self.settings = settings
-        self.glucoseInMgDl = glucoseInMgDl
-        self.predictedGlucoseInMgDl = predictedGlucoseInMgDl
-        self.insulinOnBoard = insulinOnBoard
-        self.insulinSensitivity = insulinSensitivity
-        self.basalRate = basalRate
-        self.tempBasal = tempBasal
-        self.shadowTempBasal = shadowTempBasal
-        self.shadowPredictedAddedGlucose = shadowPredictedAddedGlucose
-        self.shadowMlAddedGlucose = shadowMlAddedGlucose
-        self.shadowAddedGlucoseDataFrame = shadowAddedGlucoseDataFrame
-        self.safetyResult = safetyResult
-        self.durationInSeconds = Date().timeIntervalSince(self.at)
-        self.mlDurationInSeconds = mlDuration
-        self.safetyDurationInSeconds = safetyDuration
-        self.proportionalControllerDurationInSeconds = proportionalControllerDuration
-        self.microBolusAmount = microBolusAmount
-        self.cgmPumpMetadata = cgmPumpMetadata
-        self.pidTempBasalResult = pidTempBasalResult
-        self.targetGlucoseInMgDl = targetGlucoseInMgDl
-    }
-    
-    static func withError(at: Date, action: ClosedLoopAction, settings: CodableSettings, cgmPumpMetadata: CgmPumpMetadata) -> ClosedLoopResult {
-        return ClosedLoopResult(at: at, action: action, settings: settings, glucoseInMgDl: nil, predictedGlucoseInMgDl: nil, insulinOnBoard: nil, insulinSensitivity: nil, basalRate: nil, tempBasal: nil, shadowTempBasal: nil, shadowPredictedAddedGlucose: nil, shadowMlAddedGlucose: nil, shadowAddedGlucoseDataFrame: nil, safetyResult: nil, mlDuration: 0, safetyDuration: 0, proportionalControllerDuration: 0, microBolusAmount: nil, cgmPumpMetadata: cgmPumpMetadata, pidTempBasalResult: nil, targetGlucoseInMgDl: nil)
-    }
-    
-    static func withResult(at: Date, action: ClosedLoopAction, settings: CodableSettings, cgmPumpMetadata: CgmPumpMetadata, glucoseInMgDl: Double, insulinOnBoard: Double, closedLoopAlgorithmResult: ClosedLoopAlgorithmResult) -> ClosedLoopResult {
-        return ClosedLoopResult(at: at, action: action, settings: settings, glucoseInMgDl: glucoseInMgDl, predictedGlucoseInMgDl: closedLoopAlgorithmResult.predictedGlucoseInMgDl, insulinOnBoard: insulinOnBoard, insulinSensitivity: closedLoopAlgorithmResult.learnedInsulinSensitivity, basalRate: closedLoopAlgorithmResult.learnedBasalRate, tempBasal: closedLoopAlgorithmResult.tempBasal, shadowTempBasal: closedLoopAlgorithmResult.shadowTempBasal, shadowPredictedAddedGlucose: closedLoopAlgorithmResult.shadowPredictedAddedGlucose, shadowMlAddedGlucose: closedLoopAlgorithmResult.shadowMlAddedGlucose, shadowAddedGlucoseDataFrame: closedLoopAlgorithmResult.shadowAddedGlucoseDataFrame, safetyResult: closedLoopAlgorithmResult.safetyResult, mlDuration: closedLoopAlgorithmResult.mlDurationInSeconds, safetyDuration: closedLoopAlgorithmResult.safetyDurationInSeconds, proportionalControllerDuration: closedLoopAlgorithmResult.proportionalControllerDurationInSeconds, microBolusAmount: closedLoopAlgorithmResult.microBolusAmount,
-                                cgmPumpMetadata: cgmPumpMetadata, pidTempBasalResult: closedLoopAlgorithmResult.pidTempBasalResult, targetGlucoseInMgDl: closedLoopAlgorithmResult.targetGlucoseInMgDl)
-    }
-}
+    public let at: Date
+    public let durationInSeconds: TimeInterval
+    public let settings: CodableSettings
+    public let cgmPumpMetadata: CgmPumpMetadata
+    public let outcome: LoopOutcome
 
-struct ClosedLoopAlgorithmResult {
-    let tempBasal: Double
-    let microBolusAmount: Double
-    let shadowTempBasal: Double // remove
-    let shadowPredictedAddedGlucose: Double // remove
-    let learnedInsulinSensitivity: Double
-    let learnedBasalRate: Double
-    let shadowMlAddedGlucose: Double? // remove
-    let shadowAddedGlucoseDataFrame: [AddedGlucoseDataRow]? // rename
-    let safetyResult: SafetyResult? // not optional
-    let mlDurationInSeconds: TimeInterval
-    let safetyDurationInSeconds: TimeInterval
-    let proportionalControllerDurationInSeconds: TimeInterval
-    let predictedGlucoseInMgDl: Double
-    let pidTempBasalResult: PIDTempBasalResult
-    let targetGlucoseInMgDl: Double
+    private init(at: Date, settings: CodableSettings, cgmPumpMetadata: CgmPumpMetadata, outcome: LoopOutcome) {
+        self.at = at
+        self.durationInSeconds = Date().timeIntervalSince(at)
+        self.settings = settings
+        self.cgmPumpMetadata = cgmPumpMetadata
+        self.outcome = outcome
+    }
+
+    public static func skipped(at: Date, reason: SkipReason, settings: CodableSettings, cgmPumpMetadata: CgmPumpMetadata) -> ClosedLoopResult {
+        ClosedLoopResult(at: at, settings: settings, cgmPumpMetadata: cgmPumpMetadata, outcome: .skipped(reason))
+    }
+
+    public static func dosed(at: Date, settings: CodableSettings, cgmPumpMetadata: CgmPumpMetadata, snapshot: LoopSnapshot) -> ClosedLoopResult {
+        ClosedLoopResult(at: at, settings: settings, cgmPumpMetadata: cgmPumpMetadata, outcome: .dosed(snapshot))
+    }
+
+    public static func pumpError(at: Date, settings: CodableSettings, cgmPumpMetadata: CgmPumpMetadata, snapshot: LoopSnapshot) -> ClosedLoopResult {
+        ClosedLoopResult(at: at, settings: settings, cgmPumpMetadata: cgmPumpMetadata, outcome: .pumpError(attempted: snapshot))
+    }
 }

--- a/ios/BioKernel/BioKernel/LoopKitSupport/DeviceDataManager.swift
+++ b/ios/BioKernel/BioKernel/LoopKitSupport/DeviceDataManager.swift
@@ -89,19 +89,17 @@ public class DeviceDataManagerObservableObject: ObservableObject {
     
     func digestionCalibrated() -> Double? {
         guard let lastRun = lastClosedLoopRun else { return nil }
-        
+
         let tooOld = Date() - 16.minutesToSeconds()
         guard lastRun.at > tooOld else { return nil }
-        
-        guard let addedGlucose = lastRun.shadowPredictedAddedGlucose else { return nil }
-        guard let basalRate = lastRun.basalRate else { return nil }
-        guard let insulinSensitivity = lastRun.insulinSensitivity else { return nil }
-        
+
+        guard let snapshot = lastRun.outcome.snapshot else { return nil }
+
         // added glucose is for an hour, so the basalRate = basalInsulin
-        let basalGlucose = insulinSensitivity * basalRate
-        
+        let basalGlucose = snapshot.insulinSensitivity * snapshot.basalRate
+
         // assume that 200 mg/dl is the max added glucose, aim for 0 -> 100
-        return 100 * (addedGlucose - basalGlucose) / 200
+        return 100 * (snapshot.predictedAddedGlucoseInMgDlPerHour - basalGlucose) / 200
     }
 }
 

--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -99,7 +99,7 @@ actor LocalClosedLoopService: ClosedLoopService {
     }
     
     func microBolusAmount(tempBasal: Double, settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, at: Date) async -> Double? {
-        guard lastMicroBolus.map({ Date().timeIntervalSince($0) > microBolusThrottleInSeconds }) ?? true else { return nil }
+        guard lastMicroBolus.map({ at.timeIntervalSince($0) > microBolusThrottleInSeconds }) ?? true else { return nil }
 
         let glucoseThreshold = targetGlucoseInMgDl + microBolusGlucoseMarginMgDl
         guard glucoseInMgDl >= glucoseThreshold else { return nil }

--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -25,7 +25,19 @@ protocol ClosedLoopService {
 
 actor LocalClosedLoopService: ClosedLoopService {
     static let shared = LocalClosedLoopService()
-    
+
+    // Suspend insulin delivery when biological-invariant error drops below this.
+    let biologicalInvariantThresholdMgDlPerHour: Double = -35
+
+    // Below this the bolus rounds to zero on supported pumps (Omnipod delivers in 0.05U increments).
+    let minimumMicroBolusUnits: Double = 0.025
+
+    // 4.2 minutes — copied from the Loop project's micro-bolus cadence.
+    let microBolusThrottleInSeconds: TimeInterval = 252
+
+    // Only consider a micro-bolus when glucose is at least this far above target.
+    let microBolusGlucoseMarginMgDl: Double = 20
+
     var closedLoopResults: [ClosedLoopResult] = []
     var storage = getStoredObject().create(fileName: "closed_loop_results.json")
     var lastClosedLoopRun: ClosedLoopResult? = nil
@@ -42,10 +54,9 @@ actor LocalClosedLoopService: ClosedLoopService {
     
     func updateFilteredGlucoseChartData() async {
         let filteredGlucose: [FilteredGlucose] = closedLoopResults.compactMap { closedLoop in
-            guard let pidTempBasalResult = closedLoop.pidTempBasalResult else {
-                return nil
-            }
-            return FilteredGlucose(glucose: pidTempBasalResult.filteredGlucose, at: pidTempBasalResult.at)
+            guard let snapshot = closedLoop.outcome.snapshot else { return nil }
+            let pid = snapshot.pidTempBasalResult
+            return FilteredGlucose(glucose: pid.filteredGlucose, at: pid.at)
         }
         await getDeviceDataManager().update(filteredGlucoseChartData: filteredGlucose.sorted{ $0.at < $1.at })
     }
@@ -83,15 +94,14 @@ actor LocalClosedLoopService: ClosedLoopService {
         lastClosedLoopRun = lastRun
         
         isRunningLoop = false
-        return lastRun.action == .setTempBasal
+        if case .dosed = lastRun.outcome { return true }
+        return false
     }
     
     func microBolusAmount(tempBasal: Double, settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, at: Date) async -> Double? {
-        // make sure that we haven't issued a micro bolus in the last 4.2 minutes
-        guard lastMicroBolus.map({ Date().timeIntervalSince($0) > 4.2.minutesToSeconds() }) ?? true else { return nil }
+        guard lastMicroBolus.map({ Date().timeIntervalSince($0) > microBolusThrottleInSeconds }) ?? true else { return nil }
 
-        // make sure we're at least 20 mg/dl above our target
-        let glucoseThreshold = targetGlucoseInMgDl + 20
+        let glucoseThreshold = targetGlucoseInMgDl + microBolusGlucoseMarginMgDl
         guard glucoseInMgDl >= glucoseThreshold else { return nil }
         
         // convert the temp basal to the amount of insulin the closed loop algorithm
@@ -125,83 +135,85 @@ actor LocalClosedLoopService: ClosedLoopService {
         let settings = await getSettingsStorage().snapshot()
         let freshnessInterval = settings.freshnessIntervalInSeconds
         let cgmPumpMetadata = await getDeviceDataManager().cgmPumpMetadata()
-        
+
         print("Looping!")
         guard settings.closedLoopEnabled else {
             print("Open loop mode, bailing")
-            return ClosedLoopResult.withError(at: at, action: .openLoop, settings: settings, cgmPumpMetadata: cgmPumpMetadata)
+            return .skipped(at: at, reason: .openLoop, settings: settings, cgmPumpMetadata: cgmPumpMetadata)
         }
-        
+
         guard let glucoseReading = await getGlucoseStorage().lastReading(), at.timeIntervalSince(glucoseReading.date) < freshnessInterval else {
             print("Unable to get fresh glucose reading")
-            return ClosedLoopResult.withError(at: at, action: .glucoseReadingStale, settings: settings, cgmPumpMetadata: cgmPumpMetadata)
+            return .skipped(at: at, reason: .glucoseReadingStale, settings: settings, cgmPumpMetadata: cgmPumpMetadata)
         }
-        
+
         guard let lastPumpSync = await getInsulinStorage().lastPumpSync(), at.timeIntervalSince(lastPumpSync) < freshnessInterval else {
             print("Unable to get fresh insulin data from the pump")
-            return ClosedLoopResult.withError(at: at, action: .pumpReadingStale, settings: settings, cgmPumpMetadata: cgmPumpMetadata)
+            return .skipped(at: at, reason: .pumpReadingStale, settings: settings, cgmPumpMetadata: cgmPumpMetadata)
         }
-        
+
         // FIXME: should we care if data is from the future???
-        
+
         guard let pumpManager = await getDeviceDataManager().pumpManager else {
             print("no pump manager")
-            return ClosedLoopResult.withError(at: at, action: .noPumpManager, settings: settings, cgmPumpMetadata: cgmPumpMetadata)
+            return .skipped(at: at, reason: .noPumpManager, settings: settings, cgmPumpMetadata: cgmPumpMetadata)
         }
-        
+
         let glucoseInMgDl = glucoseReading.quantity.doubleValue(for: .milligramsPerDeciliter)
         let insulinOnBoard = await getInsulinStorage().insulinOnBoard(at: at)
-        
+
         let round = { (tempBasal: Double) -> Double in
             pumpManager.roundToSupportedBasalRate(unitsPerHour: tempBasal)
         }
-        
-        let closedLoopAlgorithmResult = await closedLoopAlgorithm(settings: settings, glucoseInMgDl: glucoseInMgDl, insulinOnBoard: insulinOnBoard, at: at, roundToSupportedBasalRate: round)
-        print("Looping, glucose: \(glucoseInMgDl) mg/dl, iob: \(insulinOnBoard), tempBasal: \(closedLoopAlgorithmResult.tempBasal)")
-        
+
+        let snapshot = await closedLoopAlgorithm(settings: settings, glucoseInMgDl: glucoseInMgDl, insulinOnBoard: insulinOnBoard, at: at, roundToSupportedBasalRate: round)
+        print("Looping, glucose: \(glucoseInMgDl) mg/dl, iob: \(insulinOnBoard), decision: \(snapshot.decision)")
+
+        let tempBasalToProgram: Double = {
+            if case .tempBasal(let units) = snapshot.decision { return units }
+            return 0.0
+        }()
+
         let correctionDuration = settings.correctionDurationInSeconds
-        if let pumpError = await pumpManager.enactTempBasal(unitsPerHour: closedLoopAlgorithmResult.tempBasal, for: correctionDuration) {
+        if let pumpError = await pumpManager.enactTempBasal(unitsPerHour: tempBasalToProgram, for: correctionDuration) {
             print("Pump error: \(String(describing: pumpError))")
-            return ClosedLoopResult.withResult(at: at, action: .pumpError, settings: settings, cgmPumpMetadata: cgmPumpMetadata, glucoseInMgDl: glucoseInMgDl, insulinOnBoard: insulinOnBoard, closedLoopAlgorithmResult: closedLoopAlgorithmResult)
+            return .pumpError(at: at, settings: settings, cgmPumpMetadata: cgmPumpMetadata, snapshot: snapshot)
         }
 
-        if closedLoopAlgorithmResult.microBolusAmount > 0.025 && settings.isMicroBolusEnabled() {
-            let units = pumpManager.roundToSupportedBolusVolume(units: closedLoopAlgorithmResult.microBolusAmount)
+        if case .microBolus(let rawUnits) = snapshot.decision {
+            let units = pumpManager.roundToSupportedBolusVolume(units: rawUnits)
             if let pumpError = await pumpManager.enactBolus(units: units, activationType: .automatic) {
                 print("Pump error: \(String(describing: pumpError))")
-                return ClosedLoopResult.withResult(at: at, action: .pumpError, settings: settings, cgmPumpMetadata: cgmPumpMetadata, glucoseInMgDl: glucoseInMgDl, insulinOnBoard: insulinOnBoard, closedLoopAlgorithmResult: closedLoopAlgorithmResult)
+                return .pumpError(at: at, settings: settings, cgmPumpMetadata: cgmPumpMetadata, snapshot: snapshot)
             }
             lastMicroBolus = Date()
         }
-        
-        // if we got here the temp basal command was sent to the pump
-        // successfully
-        if let safetyResult = closedLoopAlgorithmResult.safetyResult {
-            await getSafetyService().updateAfterProgrammingPump(
-                at: at,
-                programmedTempBasalUnitsPerHour: safetyResult.actualTempBasal,
-                safetyTempBasalUnitsPerHour: safetyResult.physiologicalTempBasal,
-                machineLearningTempBasalUnitsPerHour: safetyResult.machineLearningTempBasal,
-                duration: settings.correctionDurationInSeconds,
-                programmedMicroBolus: safetyResult.actualMicroBolus,
-                safetyMicroBolus: safetyResult.physiologicalMicroBolus,
-                machineLearningMicroBolus: safetyResult.machineLearningMicroBolus,
-                biologicalInvariantViolation: safetyResult.biologicalInvariantViolation
-            )
-        }
 
-        
+        // if we got here the pump commands were sent successfully
+        let safetyResult = snapshot.safetyResult
+        await getSafetyService().updateAfterProgrammingPump(
+            at: at,
+            programmedTempBasalUnitsPerHour: safetyResult.actualTempBasal,
+            safetyTempBasalUnitsPerHour: safetyResult.physiologicalTempBasal,
+            machineLearningTempBasalUnitsPerHour: safetyResult.machineLearningTempBasal,
+            duration: settings.correctionDurationInSeconds,
+            programmedMicroBolus: safetyResult.actualMicroBolus,
+            safetyMicroBolus: safetyResult.physiologicalMicroBolus,
+            machineLearningMicroBolus: safetyResult.machineLearningMicroBolus,
+            biologicalInvariantViolation: safetyResult.biologicalInvariantViolation
+        )
+
         // FIXME: I think I got the beeping to stop
         // podExpiring
-        
+
         pumpManager.acknowledgeAlert(alertIdentifier: "userPodExpiration") { error in
             print("alert acknowledged \(String(describing: error))")
         }
         pumpManager.acknowledgeAlert(alertIdentifier: "podExpiring") { error in
             print("alert acknowledged \(String(describing: error))")
         }
-        
-        return ClosedLoopResult.withResult(at: at, action: .setTempBasal, settings: settings, cgmPumpMetadata: cgmPumpMetadata, glucoseInMgDl: glucoseInMgDl, insulinOnBoard: insulinOnBoard, closedLoopAlgorithmResult: closedLoopAlgorithmResult)
+
+        return .dosed(at: at, settings: settings, cgmPumpMetadata: cgmPumpMetadata, snapshot: snapshot)
     }
     
     /// Pre conditions:
@@ -212,8 +224,8 @@ actor LocalClosedLoopService: ClosedLoopService {
     ///  - return is between 0 and maxBasalRate
     ///  Invariants:
     ///  - no numerical underflow or overflow
-    func closedLoopAlgorithm(settings: CodableSettings, glucoseInMgDl: Double, insulinOnBoard: Double, at: Date, roundToSupportedBasalRate: (Double) -> Double) async -> ClosedLoopAlgorithmResult {
-        
+    func closedLoopAlgorithm(settings: CodableSettings, glucoseInMgDl: Double, insulinOnBoard: Double, at: Date, roundToSupportedBasalRate: (Double) -> Double) async -> LoopSnapshot {
+
         // create a dataframe to pass to all of the callers
         let dataFrame = await AddedGlucoseDataFrame.createDataFrame(at: at, numberOfRows: 24, minNumberOfGlucoseSamples: 20)
         let basalRate = settings.learnedBasalRate(at: at)
@@ -226,63 +238,111 @@ actor LocalClosedLoopService: ClosedLoopService {
 
         let physiologicalTempBasal = applyGuardrails(glucoseInMgDl: glucoseInMgDl, predictedGlucoseInMgDl: predictedGlucoseInMgDl, newBasalRateRaw: pidTempBasal.tempBasal, settings: settings, roundToSupportedBasalRate: roundToSupportedBasalRate)
         let proportionalControllerDuration = Date().timeIntervalSince(proportionalControllerStart)
-        
+
         // calculate the ML-based tempBasal
         let mlStart = Date()
         let mlTempBasalRaw = await getMachineLearning().tempBasal(settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, insulinOnBoard: insulinOnBoard, dataFrame: dataFrame, at: at, pidTempBasal: pidTempBasal) ?? physiologicalTempBasal
         let mlTempBasal = applyGuardrails(glucoseInMgDl: glucoseInMgDl, predictedGlucoseInMgDl: predictedGlucoseInMgDl, newBasalRateRaw: mlTempBasalRaw, settings: settings, roundToSupportedBasalRate: roundToSupportedBasalRate)
         let mlDuration = Date().timeIntervalSince(mlStart)
-        
+
         // run it through the safety service
         let safetyStart = Date()
         let safetyTempBasalResult = await getSafetyService().tempBasal(at: at, settings: settings, safetyTempBasalUnitsPerHour: physiologicalTempBasal, machineLearningTempBasalUnitsPerHour: mlTempBasal, duration: settings.correctionDurationInSeconds)
         let safetyTempBasal = applyGuardrails(glucoseInMgDl: glucoseInMgDl, predictedGlucoseInMgDl: predictedGlucoseInMgDl, newBasalRateRaw: safetyTempBasalResult.tempBasal, settings: settings, roundToSupportedBasalRate: roundToSupportedBasalRate)
         let safetyDuration = Date().timeIntervalSince(safetyStart)
-        
+
         // calculate the micro bolus candidates and the biological invariant
         // IMPORTANT: you must run the mlTempBasal through the safety logic and use only
         // that temp basal for micro bolus calculations, or you can use the physiological temp basal
         let microBolusSafety = await microBolusAmount(tempBasal: safetyTempBasal, settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, at: at) ?? 0.0
         let microBolusPhysiological = await microBolusAmount(tempBasal: physiologicalTempBasal, settings: settings, glucoseInMgDl: glucoseInMgDl, targetGlucoseInMgDl: targetGlucoseInMgDl, at: at) ?? 0.0
         let biologicalInvariant = await getPhysiologicalModels().deltaGlucoseError(settings: settings, dataFrame: dataFrame, at: at)
-        
-        let dose = determineDose(settings: settings, physiologicalTempBasal: physiologicalTempBasal, mlTempBasal: mlTempBasal, safetyTempBasal: safetyTempBasal, microBolusPhysiological: microBolusPhysiological, microBolusSafety: microBolusSafety, biologicalInvariant: biologicalInvariant, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
-        
+
+        let decision = determineDose(settings: settings, physiologicalTempBasal: physiologicalTempBasal, mlTempBasal: mlTempBasal, safetyTempBasal: safetyTempBasal, microBolusPhysiological: microBolusPhysiological, microBolusSafety: microBolusSafety, biologicalInvariant: biologicalInvariant)
+
+        let machineLearningInsulinLastThreeHours = safetyTempBasalResult.machineLearningInsulinLastThreeHours
+        let safetyResult: SafetyResult
+        switch decision {
+        case .tempBasal(let unitsPerHour):
+            safetyResult = SafetyResult(
+                machineLearningTempBasal: mlTempBasal,
+                physiologicalTempBasal: physiologicalTempBasal,
+                actualTempBasal: unitsPerHour,
+                machineLearningMicroBolus: 0.0,
+                physiologicalMicroBolus: 0.0,
+                actualMicroBolus: 0.0,
+                machineLearningInsulinLastThreeHours: machineLearningInsulinLastThreeHours,
+                biologicalInvariantMgDlPerHour: biologicalInvariant,
+                biologicalInvariantViolation: false
+            )
+        case .microBolus(let units):
+            safetyResult = SafetyResult(
+                machineLearningTempBasal: 0.0,
+                physiologicalTempBasal: 0.0,
+                actualTempBasal: 0.0,
+                machineLearningMicroBolus: microBolusSafety,
+                physiologicalMicroBolus: microBolusPhysiological,
+                actualMicroBolus: units,
+                machineLearningInsulinLastThreeHours: machineLearningInsulinLastThreeHours,
+                biologicalInvariantMgDlPerHour: biologicalInvariant,
+                biologicalInvariantViolation: false
+            )
+        case .suspendForBiologicalInvariant(let mgDlPerHour):
+            safetyResult = SafetyResult(
+                machineLearningTempBasal: 0.0,
+                physiologicalTempBasal: 0.0,
+                actualTempBasal: 0.0,
+                machineLearningMicroBolus: 0.0,
+                physiologicalMicroBolus: 0.0,
+                actualMicroBolus: 0.0,
+                machineLearningInsulinLastThreeHours: machineLearningInsulinLastThreeHours,
+                biologicalInvariantMgDlPerHour: mgDlPerHour,
+                biologicalInvariantViolation: true
+            )
+        }
+
         // just for logging for now
         let addedGlucose = dataFrame?.addedGlucosePerHour30m(insulinSensitivity: insulinSensitivity) ?? 0
-        
-        return ClosedLoopAlgorithmResult(tempBasal: dose.tempBasal, microBolusAmount: dose.microBolus, shadowTempBasal: 0.0, shadowPredictedAddedGlucose: addedGlucose, learnedInsulinSensitivity: insulinSensitivity, learnedBasalRate: basalRate, shadowMlAddedGlucose: 0.0, shadowAddedGlucoseDataFrame: dataFrame, safetyResult: dose.safetyResult, mlDurationInSeconds: mlDuration, safetyDurationInSeconds: safetyDuration, proportionalControllerDurationInSeconds: proportionalControllerDuration, predictedGlucoseInMgDl: predictedGlucoseInMgDl, pidTempBasalResult: pidTempBasal, targetGlucoseInMgDl: targetGlucoseInMgDl)
+
+        return LoopSnapshot(
+            glucoseInMgDl: glucoseInMgDl,
+            predictedGlucoseInMgDl: predictedGlucoseInMgDl,
+            insulinOnBoard: insulinOnBoard,
+            targetGlucoseInMgDl: targetGlucoseInMgDl,
+            insulinSensitivity: insulinSensitivity,
+            basalRate: basalRate,
+            decision: decision,
+            safetyResult: safetyResult,
+            pidTempBasalResult: pidTempBasal,
+            mlDurationInSeconds: mlDuration,
+            safetyDurationInSeconds: safetyDuration,
+            proportionalControllerDurationInSeconds: proportionalControllerDuration,
+            predictedAddedGlucoseInMgDlPerHour: addedGlucose
+        )
     }
-    
-    /// post condition: either tempBasal _or_ microBolus can be > 0 but not both
-    func determineDose(settings: CodableSettings, physiologicalTempBasal: Double, mlTempBasal: Double, safetyTempBasal: Double, microBolusPhysiological: Double, microBolusSafety: Double, biologicalInvariant: Double?, machineLearningInsulinLastThreeHours: Double) -> (tempBasal: Double, microBolus: Double, safetyResult: SafetyResult) {
-        var tempBasal: Double
-        var microBolus: Double
-        var microBolusCandidate: Double
-        var safetyResult: SafetyResult
-        
+
+    /// post condition: exactly one dosing branch is selected per tick
+    func determineDose(settings: CodableSettings, physiologicalTempBasal: Double, mlTempBasal: Double, safetyTempBasal: Double, microBolusPhysiological: Double, microBolusSafety: Double, biologicalInvariant: Double?) -> DosingDecision {
+        let tempBasalCandidate: Double
+        let microBolusCandidate: Double
+
         if settings.useMachineLearningClosedLoop {
-            tempBasal = safetyTempBasal
+            tempBasalCandidate = safetyTempBasal
             microBolusCandidate = microBolusSafety
         } else {
-            tempBasal = physiologicalTempBasal
+            tempBasalCandidate = physiologicalTempBasal
             microBolusCandidate = microBolusPhysiological
         }
-        
-        if settings.isBiologicalInvariantEnabled(), let biologicalInvariant = biologicalInvariant, biologicalInvariant < -35 {
-            microBolus = 0.0
-            tempBasal = 0.0
-            safetyResult = SafetyResult.withBiologicalInvariantViolation(biologicalInvariantMgDlPerHour: biologicalInvariant, machineLearningInsulinLastThreeHours: machineLearningInsulinLastThreeHours)
-        } else if settings.isMicroBolusEnabled(), microBolusCandidate > 0.025 {
-            microBolus = microBolusCandidate
-            tempBasal = 0.0
-            safetyResult = SafetyResult.withMicroBolus(machineLearningMicroBolus: microBolusSafety, physiologicalMicroBolus: microBolusPhysiological, actualMicroBolus: microBolus, machineLearningInsulinLastThreeHours: machineLearningInsulinLastThreeHours, biologicalInvariantMgDlPerHour: biologicalInvariant)
-        } else {
-            microBolus = 0.0
-            safetyResult = SafetyResult.withTempBasal(machineLearningTempBasal: mlTempBasal, physiologicalTempBasal: physiologicalTempBasal, actualTempBasal: tempBasal, machineLearningInsulinLastThreeHours: machineLearningInsulinLastThreeHours, biologicalInvariantMgDlPerHour: biologicalInvariant)
+
+        if settings.isBiologicalInvariantEnabled(), let biologicalInvariant = biologicalInvariant, biologicalInvariant < biologicalInvariantThresholdMgDlPerHour {
+            return .suspendForBiologicalInvariant(mgDlPerHour: biologicalInvariant)
         }
-        
-        return (tempBasal: tempBasal, microBolus: microBolus, safetyResult: safetyResult)
+
+        if settings.isMicroBolusEnabled(), microBolusCandidate > minimumMicroBolusUnits {
+            return .microBolus(units: microBolusCandidate)
+        }
+
+        return .tempBasal(unitsPerHour: tempBasalCandidate)
     }
     
     func applyGuardrails(glucoseInMgDl: Double, predictedGlucoseInMgDl: Double, newBasalRateRaw: Double, settings: CodableSettings, roundToSupportedBasalRate: (Double) -> Double) -> Double {

--- a/ios/BioKernel/BioKernel/ViewModels/DiagnosticViewModel.swift
+++ b/ios/BioKernel/BioKernel/ViewModels/DiagnosticViewModel.swift
@@ -66,7 +66,7 @@ class DiagnosticViewModel: ObservableObject, ClosedLoopChartDataUpdate, PumpEven
     init() {
         Task { @MainActor in
             let results = await self.closedLoopService.registerClosedLoopChartDataDelegate(delegate: self)
-            self.chartData = results.filter({ $0.action == .setTempBasal }).map { self.convertToChartData(result: $0) }
+            self.chartData = results.compactMap { self.convertToChartData(result: $0) }
         }
         
         Task {
@@ -150,43 +150,55 @@ class DiagnosticViewModel: ObservableObject, ClosedLoopChartDataUpdate, PumpEven
     // MARK: - ClosedLoopChartDataUpdate
     func update(result: ClosedLoopResult) {
         DispatchQueue.main.async {
-            if result.action == .setTempBasal {
-                self.chartData.append(self.convertToChartData(result: result))
+            if let chart = self.convertToChartData(result: result) {
+                self.chartData.append(chart)
             }
         }
     }
-    
-    private func convertToChartData(result: ClosedLoopResult) -> ClosedLoopChartData {
-        let pidResult = result.pidTempBasalResult
-        let safetyResult = result.safetyResult
-        
-        let proportionalContribution = (pidResult?.Kp ?? 0) * (pidResult?.error ?? 0)
-        let derivativeContribution = (pidResult?.Kd ?? 0) * (pidResult?.derivative ?? 0)
-        let integratorContribution = (pidResult?.Ki ?? 0) * (pidResult?.accumulatedError ?? 0)
+
+    private func convertToChartData(result: ClosedLoopResult) -> ClosedLoopChartData? {
+        guard case .dosed(let snapshot) = result.outcome else { return nil }
+
+        let pid = snapshot.pidTempBasalResult
+        let safetyResult = snapshot.safetyResult
+
+        let derivative = pid.derivative ?? 0
+        let proportionalContribution = pid.Kp * pid.error
+        let derivativeContribution = pid.Kd * derivative
+        let integratorContribution = pid.Ki * pid.accumulatedError
         let totalPidContribution = proportionalContribution + derivativeContribution + integratorContribution
-        
-        let mlInsulin = (safetyResult?.machineLearningTempBasal ?? 0) / 12 + (safetyResult?.machineLearningMicroBolus ?? 0)
-        let physiologicalInsulin = (safetyResult?.physiologicalTempBasal ?? 0) / 12 + (safetyResult?.physiologicalMicroBolus ?? 0)
-        let actualInsulin = (safetyResult?.actualTempBasal ?? 0) / 12 + (safetyResult?.actualMicroBolus ?? 0)
-        
+
+        let mlInsulin = safetyResult.machineLearningTempBasal / 12 + safetyResult.machineLearningMicroBolus
+        let physiologicalInsulin = safetyResult.physiologicalTempBasal / 12 + safetyResult.physiologicalMicroBolus
+        let actualInsulin = safetyResult.actualTempBasal / 12 + safetyResult.actualMicroBolus
+
+        let tempBasal: Double = {
+            if case .tempBasal(let units) = snapshot.decision { return units }
+            return 0
+        }()
+        let microBolus: Double = {
+            if case .microBolus(let units) = snapshot.decision { return units }
+            return 0
+        }()
+
         return ClosedLoopChartData(
             at: result.at,
-            glucose: result.glucoseInMgDl ?? 0,
-            insulinOnBoard: result.insulinOnBoard ?? 0,
-            basalRate: result.basalRate ?? 0,
-            basalRateInsulinOnBoard: result.pidTempBasalResult?.basalRateInsulinOnBoard ?? 0,
+            glucose: snapshot.glucoseInMgDl,
+            insulinOnBoard: snapshot.insulinOnBoard,
+            basalRate: snapshot.basalRate,
+            basalRateInsulinOnBoard: pid.basalRateInsulinOnBoard ?? 0,
             proportionalContribution: proportionalContribution,
             derivativeContribution: derivativeContribution,
             integratorContribution: integratorContribution,
             totalPidContribution: totalPidContribution,
-            deltaGlucoseError: pidResult?.deltaGlucoseError ?? 0,
-            accumulatedError: pidResult?.accumulatedError ?? 0,
+            deltaGlucoseError: pid.deltaGlucoseError ?? 0,
+            accumulatedError: pid.accumulatedError,
             mlInsulin: mlInsulin,
             physiologicalInsulin: physiologicalInsulin,
             actualInsulin: actualInsulin,
-            machineLearningInsulinLastThreeHours: safetyResult?.machineLearningInsulinLastThreeHours ?? 0,
-            tempBasal: result.tempBasal ?? 0,
-            microBolusAmount: result.microBolusAmount ?? 0
+            machineLearningInsulinLastThreeHours: safetyResult.machineLearningInsulinLastThreeHours,
+            tempBasal: tempBasal,
+            microBolusAmount: microBolus
         )
     }
 }

--- a/ios/BioKernel/BioKernel/WatchCommsShared/SessionCommands.swift
+++ b/ios/BioKernel/BioKernel/WatchCommsShared/SessionCommands.swift
@@ -44,7 +44,7 @@ extension SessionCommands {
     //
     private func postNotificationOnMainQueueAsync(name: NSNotification.Name, object: CommandStatus) {
         DispatchQueue.main.async {
-            print("WC: postNotification name: \(name) object: \(String(describing: object))")
+            print("WC: postNotification name: \(name)")
             if let errorMessage = object.errorMessage {
                 print("WC:    errorMessage: \(errorMessage)")
             }

--- a/ios/BioKernel/BioKernelTests/ClosedLoopSafetyTests.swift
+++ b/ios/BioKernel/BioKernelTests/ClosedLoopSafetyTests.swift
@@ -85,10 +85,10 @@ final class ClosedLoopSafetyTests: XCTestCase {
         // Attempt to loop with stale data
         let loopResult: Bool = await closedLoop.loop(at: glucoseDate)
         XCTAssertFalse(loopResult, "Loop should not complete with stale CGM data")
-        
+
         // Verify result indicates stale data
         let result = await closedLoop.latestClosedLoopResult()
-        XCTAssertEqual(result?.action, .glucoseReadingStale)
+        XCTAssertEqual(result?.outcome.skipReason, .glucoseReadingStale)
     }
     
     // MARK: - Recovery Tests
@@ -98,7 +98,6 @@ final class ClosedLoopSafetyTests: XCTestCase {
         await settings.update(useBiologicalInvariant: true)
         
         // First create a biological invariant violation
-        let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
         var dose = await closedLoop.determineDose(
             settings: settings.snapshot(),
             physiologicalTempBasal: 1.0,
@@ -106,14 +105,13 @@ final class ClosedLoopSafetyTests: XCTestCase {
             safetyTempBasal: 1.5,
             microBolusPhysiological: 0.2,
             microBolusSafety: 0.25,
-            biologicalInvariant: -45, // This should trigger a violation
-            machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours
+            biologicalInvariant: -45 // This should trigger a violation
         )
-        
+
         // Verify system stops insulin delivery during violation
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
-        
+
         // Now test recovery when biological invariant returns to normal
         dose = await closedLoop.determineDose(
             settings: settings.snapshot(),
@@ -122,10 +120,9 @@ final class ClosedLoopSafetyTests: XCTestCase {
             safetyTempBasal: 1.5,
             microBolusPhysiological: 0.2,
             microBolusSafety: 0.25,
-            biologicalInvariant: -20, // Back to safe range
-            machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours
+            biologicalInvariant: -20 // Back to safe range
         )
-        
+
         // Verify insulin delivery resumes
         XCTAssertGreaterThan(dose.tempBasal, 0.0)
     }
@@ -222,7 +219,6 @@ final class ClosedLoopSafetyTests: XCTestCase {
             let settings = MockSettingsStorage()
             settings.update(useMicroBolus: false, useMachineLearningClosedLoop: false, useBiologicalInvariant: false)
             
-            let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
             let dose = await closedLoop.determineDose(
                 settings: settings.snapshot(),
                 physiologicalTempBasal: 1.5, // This should be selected since ML is off
@@ -230,14 +226,15 @@ final class ClosedLoopSafetyTests: XCTestCase {
                 safetyTempBasal: 2.0,
                 microBolusPhysiological: 0.0,
                 microBolusSafety: 0.0,
-                biologicalInvariant: -20,
-                machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours
+                biologicalInvariant: -20
             )
-            
+
             // Verify that the actual temp basal matches what was selected
             XCTAssertEqual(dose.tempBasal, 1.5, accuracy: iobAccuracy, "Selected temp basal should be physiological when ML is off")
-            XCTAssertEqual(dose.safetyResult.actualTempBasal, 1.5, accuracy: iobAccuracy, "Actual temp basal in safety result should match selected temp basal")
-            
+            guard case .tempBasal(let selectedUnits) = dose else {
+                return XCTFail("Expected dose to be a temp basal decision")
+            }
+            XCTAssertEqual(selectedUnits, 1.5, accuracy: iobAccuracy, "DosingDecision temp basal should match selected value")
         }
     
 }

--- a/ios/BioKernel/BioKernelTests/ClosedLoopTests.swift
+++ b/ios/BioKernel/BioKernelTests/ClosedLoopTests.swift
@@ -54,10 +54,7 @@ final class ClosedLoopTests: XCTestCase {
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: false, useMachineLearningClosedLoop: false, useBiologicalInvariant: false)
         
-        // this is just for logging
-        let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
-
-        let dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+let dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
         
         XCTAssertEqual(dose.tempBasal, 1.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
@@ -68,10 +65,7 @@ final class ClosedLoopTests: XCTestCase {
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: false, useMachineLearningClosedLoop: true, useBiologicalInvariant: false)
         
-        // this is just for logging
-        let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
-
-        let dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+let dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
         
         XCTAssertEqual(dose.tempBasal, 1.5, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
@@ -82,10 +76,7 @@ final class ClosedLoopTests: XCTestCase {
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: true, useMachineLearningClosedLoop: true, useBiologicalInvariant: false)
         
-        // this is just for logging
-        let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
-
-        let dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+let dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.25, accuracy: iobAccuracy)
@@ -96,15 +87,12 @@ final class ClosedLoopTests: XCTestCase {
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: true, useMachineLearningClosedLoop: false, useBiologicalInvariant: false)
         
-        // this is just for logging
-        let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
-
-        var dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+var dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.2, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.02, microBolusSafety: 0.25, biologicalInvariant: nil, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.02, microBolusSafety: 0.25, biologicalInvariant: nil)
         
         XCTAssertEqual(dose.tempBasal, 1.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
@@ -115,20 +103,17 @@ final class ClosedLoopTests: XCTestCase {
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: false, useMachineLearningClosedLoop: false, useBiologicalInvariant: true)
         
-        // this is just for logging
-        let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
-
-        var dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+var dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25)
         
         XCTAssertEqual(dose.tempBasal, 1.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
         
         XCTAssertEqual(dose.tempBasal, 1.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
@@ -139,20 +124,17 @@ final class ClosedLoopTests: XCTestCase {
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: true, useMachineLearningClosedLoop: false, useBiologicalInvariant: true)
         
-        // this is just for logging
-        let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
-
-        var dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+var dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.2, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.2, accuracy: iobAccuracy)
@@ -163,20 +145,17 @@ final class ClosedLoopTests: XCTestCase {
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: false, useMachineLearningClosedLoop: true, useBiologicalInvariant: true)
         
-        // this is just for logging
-        let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
-
-        var dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+var dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25)
         
         XCTAssertEqual(dose.tempBasal, 1.5, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
         
         XCTAssertEqual(dose.tempBasal, 1.5, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
@@ -187,20 +166,17 @@ final class ClosedLoopTests: XCTestCase {
         let settings = await MockSettingsStorage()
         await settings.update(useMicroBolus: true, useMachineLearningClosedLoop: true, useBiologicalInvariant: true)
         
-        // this is just for logging
-        let safetyTempBasalResult = SafetyTempBasal(tempBasal: 1.0, machineLearningInsulinLastThreeHours: 0.0)
-
-        var dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+var dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -25)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.25, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: -45)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.0, accuracy: iobAccuracy)
         
-        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil, machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours)
+        dose = await closedLoop.determineDose(settings: settings.snapshot(), physiologicalTempBasal: 1.0, mlTempBasal: 2.0, safetyTempBasal: 1.5, microBolusPhysiological: 0.2, microBolusSafety: 0.25, biologicalInvariant: nil)
         
         XCTAssertEqual(dose.tempBasal, 0.0, accuracy: iobAccuracy)
         XCTAssertEqual(dose.microBolus, 0.25, accuracy: iobAccuracy)

--- a/ios/BioKernel/BioKernelTests/LoopFunctionTests.swift
+++ b/ios/BioKernel/BioKernelTests/LoopFunctionTests.swift
@@ -43,7 +43,7 @@ final class LoopFunctionTests: XCTestCase {
         Dependency.mock { self.insulinStorage as InsulinStorage }
         Dependency.mock { self.deviceManager as DeviceDataManager }
         Dependency.mock { MockStoredObject.self as StoredObject.Type }
-        Dependency.mock { MockPhysiologicalModels() as PhysiologicalModels }
+        Dependency.mock { LocalPhysiologicalModels() as PhysiologicalModels }
         Dependency.mock { MockTargetGlucose() as TargetGlucoseService }
         Dependency.mock { MockMachineLearning() as MachineLearning }
         Dependency.mock { MockSafetyService() as SafetyService }
@@ -69,7 +69,7 @@ final class LoopFunctionTests: XCTestCase {
         // Verify
         XCTAssertFalse(result, "Loop should return false when closed loop is disabled")
         let lastResult = await closedLoop.latestClosedLoopResult()
-        XCTAssertEqual(lastResult?.action, .openLoop, "Action should be openLoop when closed loop is disabled")
+        XCTAssertEqual(lastResult?.outcome.skipReason, .openLoop, "Should skip with openLoop when closed loop is disabled")
     }
     
     @MainActor func testLoopWithStaleGlucoseData() async throws {
@@ -90,7 +90,7 @@ final class LoopFunctionTests: XCTestCase {
         // Verify
         XCTAssertFalse(result, "Loop should return false with stale glucose data")
         let lastResult = await closedLoop.latestClosedLoopResult()
-        XCTAssertEqual(lastResult?.action, .glucoseReadingStale, "Action should be glucoseReadingStale")
+        XCTAssertEqual(lastResult?.outcome.skipReason, .glucoseReadingStale, "Should skip with glucoseReadingStale")
     }
     
     @MainActor func testLoopWithStalePumpData() async throws {
@@ -113,7 +113,7 @@ final class LoopFunctionTests: XCTestCase {
         // Verify
         XCTAssertFalse(result, "Loop should return false with stale pump data")
         let lastResult = await closedLoop.latestClosedLoopResult()
-        XCTAssertEqual(lastResult?.action, .pumpReadingStale, "Action should be pumpReadingStale")
+        XCTAssertEqual(lastResult?.outcome.skipReason, .pumpReadingStale, "Should skip with pumpReadingStale")
     }
     
     @MainActor func testLoopWithNoPumpManager() async throws {
@@ -136,7 +136,7 @@ final class LoopFunctionTests: XCTestCase {
         // Verify
         XCTAssertFalse(result, "Loop should return false with no pump manager")
         let lastResult = await closedLoop.latestClosedLoopResult()
-        XCTAssertEqual(lastResult?.action, .noPumpManager, "Action should be noPumpManager")
+        XCTAssertEqual(lastResult?.outcome.skipReason, .noPumpManager, "Should skip with noPumpManager")
     }
     
     // MARK: - Successful Loop Tests
@@ -161,8 +161,12 @@ final class LoopFunctionTests: XCTestCase {
         // Verify
         XCTAssertTrue(result, "Loop should return true for successful temp basal")
         let lastResult = await closedLoop.latestClosedLoopResult()
-        XCTAssertEqual(lastResult?.action, .setTempBasal, "Action should be setTempBasal")
-        XCTAssertNotNil(lastResult?.tempBasal, "Temp basal should be set")
+        guard case .dosed(let snapshot) = lastResult?.outcome else {
+            return XCTFail("Outcome should be .dosed for successful temp basal")
+        }
+        guard case .tempBasal = snapshot.decision else {
+            return XCTFail("Decision should be .tempBasal")
+        }
     }
     
     @MainActor func testSuccessfulLoopWithMicroBolus() async throws {
@@ -187,8 +191,12 @@ final class LoopFunctionTests: XCTestCase {
         // Verify
         XCTAssertTrue(result, "Loop should return true for successful micro bolus")
         let lastResult = await closedLoop.latestClosedLoopResult()
-        XCTAssertEqual(lastResult?.action, .setTempBasal, "Action should be setTempBasal")
-        XCTAssertNotNil(lastResult?.microBolusAmount, "Micro bolus amount should be set")
+        guard case .dosed(let snapshot) = lastResult?.outcome else {
+            return XCTFail("Outcome should be .dosed for successful micro bolus")
+        }
+        guard case .microBolus = snapshot.decision else {
+            return XCTFail("Decision should be .microBolus")
+        }
     }
     
     @MainActor func testLoopWithPumpError() async throws {
@@ -213,7 +221,9 @@ final class LoopFunctionTests: XCTestCase {
         // Verify
         XCTAssertFalse(result, "Loop should return false when pump returns error")
         let lastResult = await closedLoop.latestClosedLoopResult()
-        XCTAssertEqual(lastResult?.action, .pumpError, "Action should be pumpError")
+        guard case .pumpError = lastResult?.outcome else {
+            return XCTFail("Outcome should be .pumpError")
+        }
     }
     
     // MARK: - Microbolus tests
@@ -240,14 +250,15 @@ final class LoopFunctionTests: XCTestCase {
         
         // Execute loop
         let loopResult: ClosedLoopResult = await closedLoop.runLoop(at: now)
-        XCTAssertEqual(loopResult.action, .setTempBasal, "Loop should complete successfully with microbolus")
-        
+        guard case .dosed(let snapshot) = loopResult.outcome else {
+            return XCTFail("Loop should complete successfully with microbolus")
+        }
+        guard case .microBolus(let units) = snapshot.decision else {
+            return XCTFail("Decision should be .microBolus")
+        }
+
         // Verify microbolus was set
-        XCTAssertNotNil(loopResult.microBolusAmount)
-        XCTAssertGreaterThan(loopResult.microBolusAmount ?? 0, 0)
-        
-        // Verify temp basal was zero (since we delivered microbolus)
-        XCTAssertEqual(loopResult.tempBasal ?? 0, 0.0, accuracy: tempBasalAccuracy)
+        XCTAssertGreaterThan(units, 0)
     }
     
     @MainActor func testLoopWithMicrobolusError() async throws {
@@ -280,9 +291,12 @@ final class LoopFunctionTests: XCTestCase {
         // Verify
         XCTAssertFalse(result, "Loop should return false when pump returns error during micro bolus")
         let lastResult = await closedLoop.latestClosedLoopResult()
-        XCTAssertEqual(lastResult?.action, .pumpError, "Action should be pumpError")
-        XCTAssertNotNil(lastResult?.microBolusAmount, "Micro bolus amount should be set even though delivery failed")
-        XCTAssertGreaterThan(lastResult?.microBolusAmount ?? 0, 0, "Micro bolus amount should be greater than 0")
-        XCTAssertEqual(lastResult?.tempBasal ?? 0, 0.0, accuracy: tempBasalAccuracy, "Temp basal should be 0 since micro bolus was attempted")
+        guard case .pumpError(let snapshot) = lastResult?.outcome else {
+            return XCTFail("Outcome should be .pumpError")
+        }
+        guard case .microBolus(let units) = snapshot.decision else {
+            return XCTFail("Decision should be .microBolus even though delivery failed")
+        }
+        XCTAssertGreaterThan(units, 0, "Micro bolus amount should be greater than 0")
     }
 }

--- a/ios/BioKernel/BioKernelTests/Utils/DosingDecisionTestHelpers.swift
+++ b/ios/BioKernel/BioKernelTests/Utils/DosingDecisionTestHelpers.swift
@@ -1,0 +1,20 @@
+//
+//  DosingDecisionTestHelpers.swift
+//  BioKernelTests
+//
+//  Created by Sam King on 4/18/26.
+//
+
+import Foundation
+@testable import BioKernel
+
+extension DosingDecision {
+    var tempBasal: Double {
+        if case .tempBasal(let units) = self { return units }
+        return 0
+    }
+    var microBolus: Double {
+        if case .microBolus(let units) = self { return units }
+        return 0
+    }
+}


### PR DESCRIPTION
This change refactors the closed loop structures we use to remove most of the optional fields and avoid illegal states by design. It cleans up some of the boiler plate code.

Note: This will change the on-disk structure for closed loop so old runs will be lost