### PR TITLE
Enable before first unlock storage access

### DIFF
--- a/ios/BioKernel/BioKernel/DependencyInjection/AppComposition.swift
+++ b/ios/BioKernel/BioKernel/DependencyInjection/AppComposition.swift
@@ -51,6 +51,14 @@ final class AppComposition {
     let observableState: AppObservableState
 
     init() {
+        // The app may be woken by CGM Bluetooth before first unlock (e.g. after
+        // an OS update overnight). Downgrade every existing file in our
+        // documents directory to FileProtectionType.none so reads on that wake
+        // path don't fail. Files written from this build forward are already
+        // .noFileProtection via StoredJsonObject / PersistedProperty; this
+        // migration only matters for files left over from prior installs.
+        AppComposition.migrateExistingFilesToNoFileProtection()
+
         // Late-bound boxes resolve cyclic dependencies. The storages need
         // WatchComms, alerts, and background-service references that don't
         // exist yet at storage-construction time; they're set before init
@@ -165,6 +173,38 @@ final class AppComposition {
         self.closedLoopService = closedLoopService
         self.deviceDataManager = deviceDataManager
         self.backgroundService = backgroundService
+    }
+}
+
+// MARK: - BFU file-protection migration
+
+extension AppComposition {
+    fileprivate static func migrateExistingFilesToNoFileProtection() {
+        let fileManager = FileManager.default
+        guard let documents = try? fileManager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false) else {
+            print("BFU migration: could not resolve documents directory")
+            return
+        }
+
+        let contents: [URL]
+        do {
+            contents = try fileManager.contentsOfDirectory(at: documents, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles])
+        } catch {
+            print("BFU migration: could not enumerate documents: \(error)")
+            return
+        }
+
+        for url in contents {
+            let isFile = (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) ?? false
+            guard isFile else { continue }
+            let currentProtection = (try? fileManager.attributesOfItem(atPath: url.path)[.protectionKey] as? FileProtectionType)?.rawValue ?? "unknown"
+            print("BFU migration: \(url.lastPathComponent) current protection: \(currentProtection)")
+            do {
+                try fileManager.setAttributes([.protectionKey: FileProtectionType.none], ofItemAtPath: url.path)
+            } catch {
+                print("BFU migration: failed to downgrade \(url.lastPathComponent): \(error)")
+            }
+        }
     }
 }
 

--- a/ios/BioKernel/BioKernel/ExtensionsAndUtils/StoredJsonObject.swift
+++ b/ios/BioKernel/BioKernel/ExtensionsAndUtils/StoredJsonObject.swift
@@ -84,7 +84,7 @@ struct StoredJsonObject: StoredObject {
                 encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             }
             let data = try encoder.encode(object)
-            try data.write(to: storageURL, options: .atomic)
+            try data.write(to: storageURL, options: [.atomic, .noFileProtection])
         } catch _ as EncodingError {
             throw StoredJsonObjectError.encodingError
         } catch {

--- a/ios/BioKernel/BioKernel/LoopKitSupport/PersistedProperty.swift
+++ b/ios/BioKernel/BioKernel/LoopKitSupport/PersistedProperty.swift
@@ -54,7 +54,7 @@ import os.log
             }
             do {
                 let data = try PropertyListSerialization.data(fromPropertyList: newValue, format: .binary, options: 0)
-                try data.write(to: storageURL, options: .atomic)
+                try data.write(to: storageURL, options: [.atomic, .noFileProtection])
                 os_log(.info, "Wrote %{public}@ to %{public}@", key, storageURL.absoluteString)
             } catch {
                 os_log(.error, "Error saving %{public}@: %{public}@", key, error.localizedDescription)

--- a/ios/BioKernel/BioKernel/Services/GlucoseAlertStorage.swift
+++ b/ios/BioKernel/BioKernel/Services/GlucoseAlertStorage.swift
@@ -71,6 +71,13 @@ public struct GlucoseAlertSettings: Codable {
     }
 }
 
+struct NotificationState: Codable {
+    var id: String?
+    var sentAt: Date?
+
+    static let none = NotificationState(id: nil, sentAt: nil)
+}
+
 @MainActor
 public protocol GlucoseAlertStorage {
     func viewModel() -> GlucoseAlertsViewModel
@@ -89,8 +96,8 @@ class PredictiveGlucoseAlertStorage: GlucoseAlertStorage {
     lazy var alertViewModel: GlucoseAlertsViewModel = GlucoseAlertsViewModel(glucoseAlertsService: self)
     var glucoseAlertSettings: GlucoseAlertSettings
     var storage: StoredObject
-    let notificationIdKey = "notificationId"
-    let notificationSentAtKey = "notificationSentAt"
+    var notificationStateStorage: StoredObject
+    var notificationState: NotificationState
 
     private let glucoseStorage: GlucoseStorage
     private let physiologicalModels: PhysiologicalModels
@@ -101,11 +108,14 @@ class PredictiveGlucoseAlertStorage: GlucoseAlertStorage {
         physiologicalModels: PhysiologicalModels
     ) {
         let storage = storedObjectFactory.create(fileName: "glucose_alerts.json")
+        let notificationStateStorage = storedObjectFactory.create(fileName: "glucose_alert_notification_state.json")
         self.storage = storage
+        self.notificationStateStorage = notificationStateStorage
         self.glucoseStorage = glucoseStorage
         self.physiologicalModels = physiologicalModels
         let settings = (try? storage.read()) ?? GlucoseAlertSettings.defaults()
         glucoseAlertSettings = settings
+        notificationState = (try? notificationStateStorage.read()) ?? .none
         DispatchQueue.main.async { [weak self] in
             self?.alertViewModel.update(settings: settings, predictedGlucose: nil)
         }
@@ -119,31 +129,28 @@ class PredictiveGlucoseAlertStorage: GlucoseAlertStorage {
     }
     
     func clearCurrentNotification() {
-        guard let notificationId = UserDefaults.standard.string(forKey: notificationIdKey) else { return }
+        guard let notificationId = notificationState.id else { return }
         NotificationManager.shared.removeDeliveredNotification(withIdentifier: notificationId)
-        UserDefaults.standard.setValue(nil, forKey: notificationIdKey)
-        UserDefaults.standard.setValue(nil, forKey: notificationSentAtKey)
+        setNotificationState(.none)
     }
-    
+
     func scheduleNotification(at: Date, alertString: String) {
         clearCurrentNotification()
         print("NOTIF: schedule notification")
         let notificationId = NotificationManager.shared.scheduleNotification(title: "BeaGL Alert", body: alertString, timeInterval: 10)
-        UserDefaults.standard.setValue(notificationId, forKey: notificationIdKey)
-        UserDefaults.standard.setValue(at, forKey: notificationSentAtKey)
+        setNotificationState(NotificationState(id: notificationId, sentAt: at))
     }
-    
+
     func updateNotification(alertString: String) {
-        guard let notificationId = UserDefaults.standard.string(forKey: notificationIdKey) else { return }
+        guard let notificationId = notificationState.id else { return }
         NotificationManager.shared.updateDeliveredNotification(withIdentifier: notificationId, newBody: alertString)
     }
-    
+
     func updateNotification(at: Date, currentState: GlucoseAlertState, nextState: GlucoseAlertState, alertString: String?) -> Bool {
         let alertString = alertString ?? "Your glucose is in range"
-        
-        let notificationSentAt = UserDefaults.standard.object(forKey: notificationSentAtKey) as? Date
+
         // add a minute to deal with sensor timing noise, etc
-        let duration = (notificationSentAt.map({ at.timeIntervalSince($0) }) ?? 24.hoursToSeconds()) + 1.minutesToSeconds()
+        let duration = (notificationState.sentAt.map({ at.timeIntervalSince($0) }) ?? 24.hoursToSeconds()) + 1.minutesToSeconds()
         print("NOTIF: duration \(duration.secondsToMinutes())m")
         switch(currentState, nextState) {
         case (_, .inRange):
@@ -237,6 +244,15 @@ class PredictiveGlucoseAlertStorage: GlucoseAlertStorage {
             try storage.write(alertSettings)
         } catch {
             print("Could not write glucose alert settings to disk")
+        }
+    }
+
+    private func setNotificationState(_ state: NotificationState) {
+        self.notificationState = state
+        do {
+            try notificationStateStorage.write(state)
+        } catch {
+            print("Could not write notification state to disk")
         }
     }
 }


### PR DESCRIPTION
This commit updates our file protection to be accessable to the app before the first device unlock. In iOS, the default file permissions make file data inaccessable until the user unlocks their phone. But if their device resets (e.g., updates in the middle of the night) and the app gets a CGM BLE message it won't be able to access any state until the user performs that first unlock. By setting `noPermission` file permissions, we ensure that all state is accessble before the first unlock.

There is a tradeoff, where these files are no longer encrypted, but this is the right tradeoff to make for AID software.