### PR TITLE
Fixes the dose progress view to show updating doses

### DIFF
--- a/ios/BioKernel/BioKernel/Views/BolusProgressView.swift
+++ b/ios/BioKernel/BioKernel/Views/BolusProgressView.swift
@@ -8,10 +8,9 @@
 import SwiftUI
 
 struct BolusProgressView: View {
-    @EnvironmentObject var appState: AppObservableState
+    @ObservedObject var doseProgress: DoseProgress
     @Environment(\.composition) var composition: AppComposition?
     var body: some View {
-        let doseProgress = appState.doseProgress
         VStack {
             Text("Delivered \(String(format: "%0.2f", doseProgress.deliveredUnits)) of \(String(format: "%0.2f", doseProgress.totalUnits)) units")
             Button {
@@ -45,5 +44,5 @@ struct BolusProgressView: View {
 }
 
 #Preview {
-    BolusProgressView()
+    BolusProgressView(doseProgress: DoseProgress())
 }

--- a/ios/BioKernel/BioKernel/Views/MainViewAlertView.swift
+++ b/ios/BioKernel/BioKernel/Views/MainViewAlertView.swift
@@ -14,7 +14,7 @@ struct MainViewAlertView: View {
     var body: some View {
         VStack {
             if !appState.doseProgress.isComplete {
-                BolusProgressView()
+                BolusProgressView(doseProgress: appState.doseProgress)
             } else if let alertString = glucoseAlertsViewModel.alertString {
                 MainViewGlucoseAlertView(alertString: alertString)
             } else {


### PR DESCRIPTION
This commit moves the doseProgress variable in the `BolusProgressView` to an @ObservedObject so that we can see the updates as they happen.