### PR TITLE
Fix bookkeeping with safety service

### DIFF
--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -191,18 +191,11 @@ actor LoopRunner: ClosedLoopService {
         }
 
         // if we got here the pump commands were sent successfully
-        let safetyAnalysis = outputs.safetyAnalysis
-        let biologicalInvariantViolation: Bool = if case .suspendForBiologicalInvariant = outputs.decision { true } else { false }
-        await safetyService.updateAfterProgrammingPump(
+        await safetyService.record(
             at: at,
-            programmedTempBasalUnitsPerHour: outputs.decision.tempBasalUnitsPerHour ?? 0,
-            safetyTempBasalUnitsPerHour: safetyAnalysis.physiologicalTempBasal,
-            machineLearningTempBasalUnitsPerHour: safetyAnalysis.machineLearningTempBasal,
-            duration: settings.correctionDurationInSeconds,
-            programmedMicroBolus: outputs.decision.microBolusUnits ?? 0,
-            safetyMicroBolus: safetyAnalysis.physiologicalMicroBolus,
-            machineLearningMicroBolus: safetyAnalysis.machineLearningMicroBolus,
-            biologicalInvariantViolation: biologicalInvariantViolation
+            decision: outputs.decision,
+            analysis: outputs.safetyAnalysis,
+            duration: settings.correctionDurationInSeconds
         )
 
         // FIXME: I think I got the beeping to stop

--- a/ios/BioKernel/BioKernel/Services/SafetyService.swift
+++ b/ios/BioKernel/BioKernel/Services/SafetyService.swift
@@ -13,6 +13,61 @@ public protocol SafetyService {
     func updateAfterProgrammingPump(at: Date, programmedTempBasalUnitsPerHour: Double, safetyTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval, programmedMicroBolus: Double, safetyMicroBolus: Double, machineLearningMicroBolus: Double, biologicalInvariantViolation: Bool) async
 }
 
+public extension SafetyService {
+    /// Records a tick from a `DosingDecision` + `SafetyAnalysis`, feeding only the
+    /// candidates from the branch that actually fired into `SafetyState`. The unused
+    /// branch's fields are 0 so `SafetyState.deltaUnits*` doesn't compare programmed=0
+    /// against an unused candidate and accumulate a phantom delta.
+    func record(at: Date, decision: DosingDecision, analysis: SafetyAnalysis, duration: TimeInterval) async {
+        let programmedTempBasal: Double
+        let safetyTempBasal: Double
+        let machineLearningTempBasal: Double
+        let programmedMicroBolus: Double
+        let safetyMicroBolus: Double
+        let machineLearningMicroBolus: Double
+        let biologicalInvariantViolation: Bool
+
+        switch decision {
+        case .tempBasal(let unitsPerHour):
+            programmedTempBasal = unitsPerHour
+            safetyTempBasal = analysis.physiologicalTempBasal
+            machineLearningTempBasal = analysis.machineLearningTempBasal
+            programmedMicroBolus = 0
+            safetyMicroBolus = 0
+            machineLearningMicroBolus = 0
+            biologicalInvariantViolation = false
+        case .microBolus(let units):
+            programmedTempBasal = 0
+            safetyTempBasal = 0
+            machineLearningTempBasal = 0
+            programmedMicroBolus = units
+            safetyMicroBolus = analysis.physiologicalMicroBolus
+            machineLearningMicroBolus = analysis.machineLearningMicroBolus
+            biologicalInvariantViolation = false
+        case .suspendForBiologicalInvariant:
+            programmedTempBasal = 0
+            safetyTempBasal = 0
+            machineLearningTempBasal = 0
+            programmedMicroBolus = 0
+            safetyMicroBolus = 0
+            machineLearningMicroBolus = 0
+            biologicalInvariantViolation = true
+        }
+
+        await updateAfterProgrammingPump(
+            at: at,
+            programmedTempBasalUnitsPerHour: programmedTempBasal,
+            safetyTempBasalUnitsPerHour: safetyTempBasal,
+            machineLearningTempBasalUnitsPerHour: machineLearningTempBasal,
+            duration: duration,
+            programmedMicroBolus: programmedMicroBolus,
+            safetyMicroBolus: safetyMicroBolus,
+            machineLearningMicroBolus: machineLearningMicroBolus,
+            biologicalInvariantViolation: biologicalInvariantViolation
+        )
+    }
+}
+
 public struct SafetyTempBasal {
     let tempBasal: Double
     let machineLearningInsulinLastThreeHours: Double

--- a/ios/BioKernel/BioKernelTests/SafetyServiceTests.swift
+++ b/ios/BioKernel/BioKernelTests/SafetyServiceTests.swift
@@ -130,6 +130,61 @@ struct SafetyServiceTests {
         #expect(abs(secondTempBasal.tempBasal - 1.0) <= insulinAccuracy)
     }
 
+    // The per-branch zeroing invariant: `record(decision:analysis:...)` must only feed
+    // candidates from the branch that actually fired into SafetyState. Without this,
+    // a .microBolus tick records programmed=0 against the unused physiologicalTempBasal
+    // candidate and SafetyState.deltaUnits* accumulates a phantom negative delta.
+    @Test func recordZeroesOutUnusedBranchFields() async throws {
+        let safetyService = LocalSafetyService(storedObjectFactory: MockStoredObject.self)
+        let startDate = Date.f("2018-07-15 03:34:29 +0000")
+        let duration = 30.minutesToSeconds()
+
+        // Both branches' candidates are non-zero, so a leak from the unused branch
+        // would show up as a non-zero stored field.
+        let analysis = SafetyAnalysis(
+            machineLearningTempBasal: 1.3,
+            physiologicalTempBasal: 0.95,
+            machineLearningMicroBolus: 0.3,
+            physiologicalMicroBolus: 0.2,
+            machineLearningInsulinLastThreeHours: 0,
+            biologicalInvariantMgDlPerHour: nil
+        )
+
+        await safetyService.record(at: startDate, decision: .tempBasal(unitsPerHour: 1.5), analysis: analysis, duration: duration)
+        await safetyService.record(at: startDate + 5.minutesToSeconds(), decision: .microBolus(units: 0.3), analysis: analysis, duration: duration)
+        await safetyService.record(at: startDate + 10.minutesToSeconds(), decision: .suspendForBiologicalInvariant(mgDlPerHour: -50), analysis: analysis, duration: duration)
+
+        let states = await safetyService.safetyStates
+        #expect(states.count == 3)
+
+        let tempBasalState = states[0]
+        #expect(tempBasalState.programmedTempBasalUnitsPerHour == 1.5)
+        #expect(tempBasalState.safetyTempBasalUnitsPerHour == 0.95)
+        #expect(tempBasalState.machineLearningTempBasalUnitsPerHour == 1.3)
+        #expect(tempBasalState.programmedMicroBolus == 0)
+        #expect(tempBasalState.safetyMicroBolus == 0)
+        #expect(tempBasalState.machineLearningMicroBolus == 0)
+        #expect(tempBasalState.biologicalInvariantViolation == false)
+
+        let microBolusState = states[1]
+        #expect(microBolusState.programmedTempBasalUnitsPerHour == 0)
+        #expect(microBolusState.safetyTempBasalUnitsPerHour == 0)
+        #expect(microBolusState.machineLearningTempBasalUnitsPerHour == 0)
+        #expect(microBolusState.programmedMicroBolus == 0.3)
+        #expect(microBolusState.safetyMicroBolus == 0.2)
+        #expect(microBolusState.machineLearningMicroBolus == 0.3)
+        #expect(microBolusState.biologicalInvariantViolation == false)
+
+        let suspendState = states[2]
+        #expect(suspendState.programmedTempBasalUnitsPerHour == 0)
+        #expect(suspendState.safetyTempBasalUnitsPerHour == 0)
+        #expect(suspendState.machineLearningTempBasalUnitsPerHour == 0)
+        #expect(suspendState.programmedMicroBolus == 0)
+        #expect(suspendState.safetyMicroBolus == 0)
+        #expect(suspendState.machineLearningMicroBolus == 0)
+        #expect(suspendState.biologicalInvariantViolation == true)
+    }
+
     @Test func lessInsulinClamp() async {
         let safetyService = LocalSafetyService(storedObjectFactory: MockStoredObject.self)
         let settings = await MockSettingsStorage()


### PR DESCRIPTION
Restore post-refactor safety logic around recording results from
microbolus and tempbasal cases correctly. The refactor incorrectly
failed to zero out the temp basal amounts for microbolus events.
