### PR TITLE
Refactor SafetyState struct

### DIFF
--- a/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
+++ b/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		3B7C6D9C2B0C09320030DFA7 /* InsulinStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7C6D9B2B0C09320030DFA7 /* InsulinStorageTests.swift */; };
 		3B7F08412B2DDE33002930A4 /* ClosedLoopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7F08402B2DDE33002930A4 /* ClosedLoopTests.swift */; };
 		3B7F08622B31590D002930A4 /* BolusProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7F08612B31590D002930A4 /* BolusProgressView.swift */; };
+		3B8704402FA68DF60005DDE0 /* SafetyStateCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B87043F2FA68DF60005DDE0 /* SafetyStateCodableTests.swift */; };
 		3B8906552E50EA9500F32799 /* DiagnosticChartScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B8906542E50EA9500F32799 /* DiagnosticChartScrollView.swift */; };
 		3B96F2542D08A2A800ABBA16 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B96F2532D08A2A800ABBA16 /* WidgetKit.framework */; };
 		3B96F2562D08A2A800ABBA16 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B96F2552D08A2A800ABBA16 /* SwiftUI.framework */; };
@@ -267,6 +268,7 @@
 		3B7C6D9B2B0C09320030DFA7 /* InsulinStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsulinStorageTests.swift; sourceTree = "<group>"; };
 		3B7F08402B2DDE33002930A4 /* ClosedLoopTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedLoopTests.swift; sourceTree = "<group>"; };
 		3B7F08612B31590D002930A4 /* BolusProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusProgressView.swift; sourceTree = "<group>"; };
+		3B87043F2FA68DF60005DDE0 /* SafetyStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyStateCodableTests.swift; sourceTree = "<group>"; };
 		3B8906542E50EA9500F32799 /* DiagnosticChartScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticChartScrollView.swift; sourceTree = "<group>"; };
 		3B96F2522D08A2A800ABBA16 /* LauncherWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LauncherWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B96F2532D08A2A800ABBA16 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
@@ -648,6 +650,7 @@
 				3B016DD92FA64E720011F6EC /* LoopOutcomeCodableTests.swift */,
 				3B40DE662D243C6C0032328F /* MicroBolusAmountTest.swift */,
 				3B348DAD2B5DAFB0000A40E9 /* SafetyServiceTests.swift */,
+				3B87043F2FA68DF60005DDE0 /* SafetyStateCodableTests.swift */,
 				3C15FE482B0C9C5000CA1FD4 /* Resources */,
 				3CAAFC8A2B0D719E00597055 /* Utils */,
 			);
@@ -955,6 +958,7 @@
 				3CAAFC8E2B0D739200597055 /* InsulinPersistentStorageTests.swift in Sources */,
 				3B40DE672D243C6C0032328F /* MicroBolusAmountTest.swift in Sources */,
 				3B7C6D9C2B0C09320030DFA7 /* InsulinStorageTests.swift in Sources */,
+				3B8704402FA68DF60005DDE0 /* SafetyStateCodableTests.swift in Sources */,
 				3BEE4E202B5FF4A000A09203 /* DateTime.swift in Sources */,
 				3CBFB98A2AFE02E90020FC90 /* InsulinOnBoardTests.swift in Sources */,
 				3B016DDA2FA64E720011F6EC /* LoopOutcomeCodableTests.swift in Sources */,

--- a/ios/BioKernel/BioKernel/DataTypes/ClosedLoopDataTypes.swift
+++ b/ios/BioKernel/BioKernel/DataTypes/ClosedLoopDataTypes.swift
@@ -85,13 +85,30 @@ public extension LoopOutcome {
     }
 }
 
-public struct SafetyAnalysis: Codable {
-    let machineLearningTempBasal: Double
-    let physiologicalTempBasal: Double
-    let machineLearningMicroBolus: Double
-    let physiologicalMicroBolus: Double
-    let machineLearningInsulinLastThreeHours: Double
-    let biologicalInvariantMgDlPerHour: Double?
+/// Per-tick candidates the dose selector chose between. Both forms (temp basal,
+/// microBolus) are computed every tick; only one fires based on settings.
+/// `mlTempBasal` is post-safety (what would actually be delivered), not the raw
+/// ML model output. `mlMicroBolus` is derived from `mlTempBasal` via the bolus policy.
+public struct DoseCandidates: Codable {
+    let physiologicalTempBasal: Double      // U/hr
+    let mlTempBasal: Double                 // U/hr — post-safety candidate
+    let physiologicalMicroBolus: Double     // U
+    let mlMicroBolus: Double                // U
+}
+
+public extension DoseCandidates {
+    /// Insulin (U over one loop interval) projected onto the branch that actually
+    /// fired. Lets diagnostics compare actual vs phys vs ML on a single axis.
+    func insulinPerLoopInterval(for decision: DosingDecision) -> (programmed: Double, physiological: Double, ml: Double) {
+        switch decision {
+        case .tempBasal(let unitsPerHour):
+            return (unitsPerHour / 12, physiologicalTempBasal / 12, mlTempBasal / 12)
+        case .microBolus(let units):
+            return (units, physiologicalMicroBolus, mlMicroBolus)
+        case .suspendForBiologicalInvariant:
+            return (0, 0, 0)
+        }
+    }
 }
 
 /// Pre conditions:
@@ -237,7 +254,8 @@ public struct PipelineOutputs: Codable {
     let insulinSensitivity: Double
     let basalRate: Double
     let pidTempBasalResult: PIDTempBasalResult
-    let safetyAnalysis: SafetyAnalysis
+    let candidates: DoseCandidates
+    let machineLearningInsulinLastThreeHours: Double
     let decision: DosingDecision
     let timings: StageTimings
     let predictedAddedGlucoseInMgDlPerHour: Double
@@ -334,13 +352,11 @@ struct DosingPipeline {
             biologicalInvariant: biologicalInvariant
         )
 
-        let safetyAnalysis = SafetyAnalysis(
-            machineLearningTempBasal: mlTempBasal,
+        let candidates = DoseCandidates(
             physiologicalTempBasal: physiologicalTempBasal,
-            machineLearningMicroBolus: microBolusSafety,
+            mlTempBasal: safetyTempBasal,
             physiologicalMicroBolus: microBolusPhysiological,
-            machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours,
-            biologicalInvariantMgDlPerHour: biologicalInvariant
+            mlMicroBolus: microBolusSafety
         )
 
         let addedGlucose = dataFrame?.addedGlucosePerHour30m(insulinSensitivity: insulinSensitivity) ?? 0
@@ -351,7 +367,8 @@ struct DosingPipeline {
             insulinSensitivity: insulinSensitivity,
             basalRate: basalRate,
             pidTempBasalResult: pidTempBasal,
-            safetyAnalysis: safetyAnalysis,
+            candidates: candidates,
+            machineLearningInsulinLastThreeHours: safetyTempBasalResult.machineLearningInsulinLastThreeHours,
             decision: decision,
             timings: StageTimings(
                 pidDurationInSeconds: pidDuration,

--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -195,7 +195,7 @@ actor LoopRunner: ClosedLoopService {
         await safetyService.record(
             at: at,
             decision: outputs.decision,
-            analysis: outputs.safetyAnalysis,
+            candidates: outputs.candidates,
             duration: settings.correctionDurationInSeconds
         )
 

--- a/ios/BioKernel/BioKernel/Services/SafetyService.swift
+++ b/ios/BioKernel/BioKernel/Services/SafetyService.swift
@@ -10,62 +10,7 @@ import LoopKit
 
 public protocol SafetyService {
     func tempBasal(at: Date, settings: CodableSettings, safetyTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval) async -> SafetyTempBasal
-    func updateAfterProgrammingPump(at: Date, programmedTempBasalUnitsPerHour: Double, safetyTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval, programmedMicroBolus: Double, safetyMicroBolus: Double, machineLearningMicroBolus: Double, biologicalInvariantViolation: Bool) async
-}
-
-public extension SafetyService {
-    /// Records a tick from a `DosingDecision` + `SafetyAnalysis`, feeding only the
-    /// candidates from the branch that actually fired into `SafetyState`. The unused
-    /// branch's fields are 0 so `SafetyState.deltaUnits*` doesn't compare programmed=0
-    /// against an unused candidate and accumulate a phantom delta.
-    func record(at: Date, decision: DosingDecision, analysis: SafetyAnalysis, duration: TimeInterval) async {
-        let programmedTempBasal: Double
-        let safetyTempBasal: Double
-        let machineLearningTempBasal: Double
-        let programmedMicroBolus: Double
-        let safetyMicroBolus: Double
-        let machineLearningMicroBolus: Double
-        let biologicalInvariantViolation: Bool
-
-        switch decision {
-        case .tempBasal(let unitsPerHour):
-            programmedTempBasal = unitsPerHour
-            safetyTempBasal = analysis.physiologicalTempBasal
-            machineLearningTempBasal = analysis.machineLearningTempBasal
-            programmedMicroBolus = 0
-            safetyMicroBolus = 0
-            machineLearningMicroBolus = 0
-            biologicalInvariantViolation = false
-        case .microBolus(let units):
-            programmedTempBasal = 0
-            safetyTempBasal = 0
-            machineLearningTempBasal = 0
-            programmedMicroBolus = units
-            safetyMicroBolus = analysis.physiologicalMicroBolus
-            machineLearningMicroBolus = analysis.machineLearningMicroBolus
-            biologicalInvariantViolation = false
-        case .suspendForBiologicalInvariant:
-            programmedTempBasal = 0
-            safetyTempBasal = 0
-            machineLearningTempBasal = 0
-            programmedMicroBolus = 0
-            safetyMicroBolus = 0
-            machineLearningMicroBolus = 0
-            biologicalInvariantViolation = true
-        }
-
-        await updateAfterProgrammingPump(
-            at: at,
-            programmedTempBasalUnitsPerHour: programmedTempBasal,
-            safetyTempBasalUnitsPerHour: safetyTempBasal,
-            machineLearningTempBasalUnitsPerHour: machineLearningTempBasal,
-            duration: duration,
-            programmedMicroBolus: programmedMicroBolus,
-            safetyMicroBolus: safetyMicroBolus,
-            machineLearningMicroBolus: machineLearningMicroBolus,
-            biologicalInvariantViolation: biologicalInvariantViolation
-        )
-    }
+    func record(at: Date, decision: DosingDecision, candidates: DoseCandidates, duration: TimeInterval) async
 }
 
 public struct SafetyTempBasal {
@@ -80,33 +25,34 @@ public struct SafetyTempBasal {
 public struct SafetyState: Codable {
     let at: Date
     let duration: TimeInterval
-    let programmedTempBasalUnitsPerHour: Double
-    let safetyTempBasalUnitsPerHour: Double
-    let machineLearningTempBasalUnitsPerHour: Double
-    let programmedMicroBolus: Double
-    let safetyMicroBolus: Double
-    let machineLearningMicroBolus: Double
-    let biologicalInvariantViolation: Bool
-    
-    private func deltaUnitsTempBasal(from: Date, to: Date) -> Double {
-        guard !safetyTempBasalUnitsPerHour.roughlyEqual(to: programmedTempBasalUnitsPerHour) else { return 0.0 }
-        let start = max(at, from)
-        let end = min(at + duration, to)
-        // make sure that this temp basal command ran for at least 1 second
-        guard end > (start + 1) else { return 0.0 }
-        let durationInSeconds = end.timeIntervalSince(start)
-        let deltaTempBasal = programmedTempBasalUnitsPerHour - safetyTempBasalUnitsPerHour
-        return deltaTempBasal * durationInSeconds / 1.hoursToSeconds()
+    let kind: Kind
+
+    /// Mirrors `DosingDecision`: exactly one branch fires per tick. Each non-suspended
+    /// case carries the programmed delivery and the physiological candidate it deviated
+    /// from; that's all `deltaUnitsDeliveredByMachineLearning` needs for the budget tally.
+    public enum Kind: Codable {
+        case tempBasal(programmed: Double, physiological: Double)   // U/hr
+        case microBolus(programmed: Double, physiological: Double)  // U
+        case suspended
     }
-    
-    private func deltaUnitsMicroBolus(from: Date, to: Date) -> Double {
-        guard !safetyMicroBolus.roughlyEqual(to: programmedMicroBolus) else { return 0.0 }
-        guard at >= from, at < to else { return 0.0 }
-        return programmedMicroBolus - safetyMicroBolus
-    }
-    
+
     func deltaUnitsDeliveredByMachineLearning(from: Date, to: Date) -> Double {
-        return deltaUnitsTempBasal(from: from, to: to) + deltaUnitsMicroBolus(from: from, to: to)
+        switch kind {
+        case .tempBasal(let programmed, let physiological):
+            guard !physiological.roughlyEqual(to: programmed) else { return 0.0 }
+            let start = max(at, from)
+            let end = min(at + duration, to)
+            // make sure that this temp basal command ran for at least 1 second
+            guard end > (start + 1) else { return 0.0 }
+            let durationInSeconds = end.timeIntervalSince(start)
+            return (programmed - physiological) * durationInSeconds / 1.hoursToSeconds()
+        case .microBolus(let programmed, let physiological):
+            guard !physiological.roughlyEqual(to: programmed) else { return 0.0 }
+            guard at >= from, at < to else { return 0.0 }
+            return programmed - physiological
+        case .suspended:
+            return 0
+        }
     }
 }
 
@@ -156,16 +102,25 @@ actor LocalSafetyService: SafetyService {
         return SafetyTempBasal(tempBasal: safetyTempBasalUnitsPerHour + deltaTempBasal, machineLearningInsulinLastThreeHours: historicalMlInsulin)
     }
     
-    func updateAfterProgrammingPump(at: Date, programmedTempBasalUnitsPerHour: Double, safetyTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval, programmedMicroBolus: Double, safetyMicroBolus: Double, machineLearningMicroBolus: Double, biologicalInvariantViolation: Bool) async {
+    func record(at: Date, decision: DosingDecision, candidates: DoseCandidates, duration: TimeInterval) async {
+        let kind: SafetyState.Kind
+        switch decision {
+        case .tempBasal(let unitsPerHour):
+            kind = .tempBasal(programmed: unitsPerHour, physiological: candidates.physiologicalTempBasal)
+        case .microBolus(let units):
+            kind = .microBolus(programmed: units, physiological: candidates.physiologicalMicroBolus)
+        case .suspendForBiologicalInvariant:
+            kind = .suspended
+        }
 
-        safetyStates.append(SafetyState(at: at, duration: duration, programmedTempBasalUnitsPerHour: programmedTempBasalUnitsPerHour, safetyTempBasalUnitsPerHour: safetyTempBasalUnitsPerHour, machineLearningTempBasalUnitsPerHour: machineLearningTempBasalUnitsPerHour, programmedMicroBolus: programmedMicroBolus, safetyMicroBolus: safetyMicroBolus, machineLearningMicroBolus: machineLearningMicroBolus, biologicalInvariantViolation: biologicalInvariantViolation))
+        safetyStates.append(SafetyState(at: at, duration: duration, kind: kind))
 
         // Only keep 24 hours worth of data
         safetyStates = safetyStates.sorted { $0.at < $1.at }
         if let mostRecent = safetyStates.last {
             safetyStates = safetyStates.filter { $0.at >= (mostRecent.at - 24.hoursToSeconds()) }
         }
-        
+
         try? storage.write(safetyStates)
     }
 }

--- a/ios/BioKernel/BioKernel/ViewModels/DiagnosticViewModel.swift
+++ b/ios/BioKernel/BioKernel/ViewModels/DiagnosticViewModel.swift
@@ -165,7 +165,6 @@ class DiagnosticViewModel: ObservableObject, ClosedLoopChartDataUpdate, PumpEven
         guard case .dosed(let snapshot) = result.outcome else { return nil }
 
         let pid = snapshot.outputs.pidTempBasalResult
-        let safetyAnalysis = snapshot.outputs.safetyAnalysis
 
         let derivative = pid.derivative ?? 0
         let proportionalContribution = pid.Kp * pid.error
@@ -176,9 +175,7 @@ class DiagnosticViewModel: ObservableObject, ClosedLoopChartDataUpdate, PumpEven
         let tempBasal: Double = snapshot.outputs.decision.tempBasalUnitsPerHour ?? 0
         let microBolus: Double = snapshot.outputs.decision.microBolusUnits ?? 0
 
-        let mlInsulin = safetyAnalysis.machineLearningTempBasal / 12 + safetyAnalysis.machineLearningMicroBolus
-        let physiologicalInsulin = safetyAnalysis.physiologicalTempBasal / 12 + safetyAnalysis.physiologicalMicroBolus
-        let actualInsulin = tempBasal / 12 + microBolus
+        let insulin = snapshot.outputs.candidates.insulinPerLoopInterval(for: snapshot.outputs.decision)
 
         return ClosedLoopChartData(
             at: result.at,
@@ -192,10 +189,10 @@ class DiagnosticViewModel: ObservableObject, ClosedLoopChartDataUpdate, PumpEven
             totalPidContribution: totalPidContribution,
             deltaGlucoseError: pid.deltaGlucoseError ?? 0,
             accumulatedError: pid.accumulatedError,
-            mlInsulin: mlInsulin,
-            physiologicalInsulin: physiologicalInsulin,
-            actualInsulin: actualInsulin,
-            machineLearningInsulinLastThreeHours: safetyAnalysis.machineLearningInsulinLastThreeHours,
+            mlInsulin: insulin.ml,
+            physiologicalInsulin: insulin.physiological,
+            actualInsulin: insulin.programmed,
+            machineLearningInsulinLastThreeHours: snapshot.outputs.machineLearningInsulinLastThreeHours,
             tempBasal: tempBasal,
             microBolusAmount: microBolus
         )

--- a/ios/BioKernel/BioKernelTests/LoopOutcomeCodableTests.swift
+++ b/ios/BioKernel/BioKernelTests/LoopOutcomeCodableTests.swift
@@ -27,13 +27,11 @@ struct LoopOutcomeCodableTests {
             deltaGlucoseError: nil,
             basalRateInsulinOnBoard: 0.53
         )
-        let safety = SafetyAnalysis(
-            machineLearningTempBasal: 0,
+        let candidates = DoseCandidates(
             physiologicalTempBasal: 0,
-            machineLearningMicroBolus: 0,
+            mlTempBasal: 0,
             physiologicalMicroBolus: 0,
-            machineLearningInsulinLastThreeHours: 0,
-            biologicalInvariantMgDlPerHour: nil
+            mlMicroBolus: 0
         )
         let outputs = PipelineOutputs(
             predictedGlucoseInMgDl: 146.5,
@@ -41,7 +39,8 @@ struct LoopOutcomeCodableTests {
             insulinSensitivity: 55,
             basalRate: 0.3,
             pidTempBasalResult: pid,
-            safetyAnalysis: safety,
+            candidates: candidates,
+            machineLearningInsulinLastThreeHours: 0,
             decision: .tempBasal(unitsPerHour: 0),
             timings: StageTimings(
                 pidDurationInSeconds: 0.0002,

--- a/ios/BioKernel/BioKernelTests/SafetyServiceTests.swift
+++ b/ios/BioKernel/BioKernelTests/SafetyServiceTests.swift
@@ -19,7 +19,7 @@ struct SafetyServiceTests {
 
     @Test func safetyStateBasics() async throws {
         let startDate = Date.f("2018-07-15 03:34:29 +0000")
-        let safetyState = SafetyState(at: startDate, duration: 30.minutesToSeconds(), programmedTempBasalUnitsPerHour: 1.2, safetyTempBasalUnitsPerHour: 1.2, machineLearningTempBasalUnitsPerHour: 1.2, programmedMicroBolus: 0.0, safetyMicroBolus: 0.0, machineLearningMicroBolus: 0.0, biologicalInvariantViolation: false)
+        let safetyState = SafetyState(at: startDate, duration: 30.minutesToSeconds(), kind: .tempBasal(programmed: 1.2, physiological: 1.2))
 
         // look at a time before our command ran
         let beforeUnits = safetyState.deltaUnitsDeliveredByMachineLearning(from: startDate - 5.minutesToSeconds(), to: startDate)
@@ -30,17 +30,11 @@ struct SafetyServiceTests {
         let unitsFromSafetyTempBasal = safetyState.deltaUnitsDeliveredByMachineLearning(from: startDate, to: startDate + 5.minutesToSeconds())
 
         #expect(abs(unitsFromSafetyTempBasal - 0.0) <= insulinAccuracy)
-
-        let safetyState2 = SafetyState(at: startDate, duration: 30.minutesToSeconds(), programmedTempBasalUnitsPerHour: 1.2, safetyTempBasalUnitsPerHour: 1.2, machineLearningTempBasalUnitsPerHour: 2.4, programmedMicroBolus: 0.0, safetyMicroBolus: 0.0, machineLearningMicroBolus: 0.0, biologicalInvariantViolation: false)
-
-        let unitsFromProgrammed = safetyState2.deltaUnitsDeliveredByMachineLearning(from: startDate, to: startDate + 5.minutesToSeconds())
-
-        #expect(abs(unitsFromProgrammed - 0.0) <= insulinAccuracy)
     }
 
     @Test func safetyStateCalculation() async throws {
         let startDate = Date.f("2018-07-15 03:34:29 +0000")
-        let safetyStateEqual = SafetyState(at: startDate, duration: 30.minutesToSeconds(), programmedTempBasalUnitsPerHour: 1.2, safetyTempBasalUnitsPerHour: 0, machineLearningTempBasalUnitsPerHour: 1.2, programmedMicroBolus: 0, safetyMicroBolus: 0, machineLearningMicroBolus: 0, biologicalInvariantViolation: false)
+        let safetyStateEqual = SafetyState(at: startDate, duration: 30.minutesToSeconds(), kind: .tempBasal(programmed: 1.2, physiological: 0))
 
         let mlInsulin = safetyStateEqual.deltaUnitsDeliveredByMachineLearning(from: startDate, to: startDate + 5.minutesToSeconds())
         #expect(abs(mlInsulin - 0.1) <= insulinAccuracy)
@@ -52,17 +46,11 @@ struct SafetyServiceTests {
         // make sure that we can start in the middle
         let mlInsulin3 = safetyStateEqual.deltaUnitsDeliveredByMachineLearning(from: startDate + 25.minutesToSeconds(), to: startDate + 60.minutesToSeconds())
         #expect(abs(mlInsulin3 - 0.1) <= insulinAccuracy)
-
-        // check when the programmed value is in between phys and ml
-        let safetyStateNotEqual = SafetyState(at: startDate, duration: 30.minutesToSeconds(), programmedTempBasalUnitsPerHour: 1.2, safetyTempBasalUnitsPerHour: 0, machineLearningTempBasalUnitsPerHour: 2.4, programmedMicroBolus: 0, safetyMicroBolus: 0, machineLearningMicroBolus: 0, biologicalInvariantViolation: false)
-
-        let mlInsulin4 = safetyStateNotEqual.deltaUnitsDeliveredByMachineLearning(from: startDate, to: startDate + 5.minutesToSeconds())
-        #expect(abs(mlInsulin4 - 0.1) <= insulinAccuracy)
     }
 
     @Test func safetyStateTempBasal() async throws {
         let startDate = Date.f("2018-07-15 03:34:29 +0000")
-        let safetyStateEqual = SafetyState(at: startDate, duration: 30.minutesToSeconds(), programmedTempBasalUnitsPerHour: 1.2, safetyTempBasalUnitsPerHour: 0, machineLearningTempBasalUnitsPerHour: 1.2, programmedMicroBolus: 0, safetyMicroBolus: 0, machineLearningMicroBolus: 0, biologicalInvariantViolation: false)
+        let safetyStateEqual = SafetyState(at: startDate, duration: 30.minutesToSeconds(), kind: .tempBasal(programmed: 1.2, physiological: 0))
 
         var mlInsulin = safetyStateEqual.deltaUnitsDeliveredByMachineLearning(from: startDate + 30.minutesToSeconds(), to: startDate + 60.minutesToSeconds())
         #expect(abs(mlInsulin - 0.0) <= insulinAccuracy)
@@ -73,7 +61,7 @@ struct SafetyServiceTests {
 
     @Test func safetyStateMicroBolus() async throws {
         let startDate = Date.f("2018-07-15 03:34:29 +0000")
-        let safetyStateEqual = SafetyState(at: startDate, duration: 1.minutesToSeconds(), programmedTempBasalUnitsPerHour: 0, safetyTempBasalUnitsPerHour: 0, machineLearningTempBasalUnitsPerHour: 0, programmedMicroBolus: 2.0, safetyMicroBolus: 0, machineLearningMicroBolus: 2.0, biologicalInvariantViolation: false)
+        let safetyStateEqual = SafetyState(at: startDate, duration: 1.minutesToSeconds(), kind: .microBolus(programmed: 2.0, physiological: 0))
 
         // checks to make sure that we're accounting for a micro bolus
         var mlInsulin = safetyStateEqual.deltaUnitsDeliveredByMachineLearning(from: startDate, to: startDate + 30.minutesToSeconds())
@@ -88,6 +76,13 @@ struct SafetyServiceTests {
         #expect(abs(mlInsulin - 0.0) <= insulinAccuracy)
     }
 
+    @Test func suspendedKindAccumulatesNoMlInsulin() async throws {
+        let startDate = Date.f("2018-07-15 03:34:29 +0000")
+        let suspended = SafetyState(at: startDate, duration: 30.minutesToSeconds(), kind: .suspended)
+        let mlInsulin = suspended.deltaUnitsDeliveredByMachineLearning(from: startDate, to: startDate + 30.minutesToSeconds())
+        #expect(abs(mlInsulin - 0.0) <= insulinAccuracy)
+    }
+
     // for this test we will deliver two ML doses that provide an excess of
     // one unit of insulin each. Then on the third the system should instead
     // use the safety insulin value since we've exausted our ML insulin
@@ -97,14 +92,16 @@ struct SafetyServiceTests {
         await settings.update(pumpBasalRateUnitsPerHour: 2.0 / 3)
         let startDate = Date.f("2018-07-15 03:34:29 +0000")
 
+        let candidates = DoseCandidates(physiologicalTempBasal: 1.0, mlTempBasal: 3.0, physiologicalMicroBolus: 0, mlMicroBolus: 0)
+
         // our first dose that will run for 30 minutes
-        await safetyService.updateAfterProgrammingPump(at: startDate, programmedTempBasalUnitsPerHour: 3.0, safetyTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds(), programmedMicroBolus: 0, safetyMicroBolus: 0, machineLearningMicroBolus: 0, biologicalInvariantViolation: false)
+        await safetyService.record(at: startDate, decision: .tempBasal(unitsPerHour: 3.0), candidates: candidates, duration: 30.minutesToSeconds())
 
         let firstTempBasal = await safetyService.tempBasal(at: startDate + 30.minutesToSeconds(), settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
 
         #expect(abs(firstTempBasal.tempBasal - 3.0) <= insulinAccuracy)
 
-        await safetyService.updateAfterProgrammingPump(at: startDate + 30.minutesToSeconds(), programmedTempBasalUnitsPerHour: firstTempBasal.tempBasal, safetyTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds(), programmedMicroBolus: 0, safetyMicroBolus: 0, machineLearningMicroBolus: 0, biologicalInvariantViolation: false)
+        await safetyService.record(at: startDate + 30.minutesToSeconds(), decision: .tempBasal(unitsPerHour: firstTempBasal.tempBasal), candidates: candidates, duration: 30.minutesToSeconds())
 
         // at this point we have already delivered 2 units from ML, which is
         // our cap so the system should fall back to the safety tempBasal
@@ -119,70 +116,61 @@ struct SafetyServiceTests {
         await settings.update(pumpBasalRateUnitsPerHour: 2.0 / 3)
         let startDate = Date.f("2018-07-15 03:34:29 +0000")
 
+        let basalCandidates = DoseCandidates(physiologicalTempBasal: 0, mlTempBasal: 1.2, physiologicalMicroBolus: 0, mlMicroBolus: 0)
+        let bolusCandidates = DoseCandidates(physiologicalTempBasal: 0, mlTempBasal: 0, physiologicalMicroBolus: 0, mlMicroBolus: 2.9)
+
         // our first dose is a temp basal
-        await safetyService.updateAfterProgrammingPump(at: startDate, programmedTempBasalUnitsPerHour: 1.2, safetyTempBasalUnitsPerHour: 0, machineLearningTempBasalUnitsPerHour: 1.2, duration: 30.minutesToSeconds(), programmedMicroBolus: 0, safetyMicroBolus: 0, machineLearningMicroBolus: 0, biologicalInvariantViolation: false)
+        await safetyService.record(at: startDate, decision: .tempBasal(unitsPerHour: 1.2), candidates: basalCandidates, duration: 30.minutesToSeconds())
 
         // add a micro bolus after 5 minutes
-        await safetyService.updateAfterProgrammingPump(at: startDate + 5.minutesToSeconds(), programmedTempBasalUnitsPerHour: 0, safetyTempBasalUnitsPerHour: 0, machineLearningTempBasalUnitsPerHour: 0, duration: 30.minutesToSeconds(), programmedMicroBolus: 2.9, safetyMicroBolus: 0, machineLearningMicroBolus: 2.9, biologicalInvariantViolation: false)
+        await safetyService.record(at: startDate + 5.minutesToSeconds(), decision: .microBolus(units: 2.9), candidates: bolusCandidates, duration: 30.minutesToSeconds())
 
         let secondTempBasal = await safetyService.tempBasal(at: startDate + 60.minutesToSeconds(), settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
 
         #expect(abs(secondTempBasal.tempBasal - 1.0) <= insulinAccuracy)
     }
 
-    // The per-branch zeroing invariant: `record(decision:analysis:...)` must only feed
-    // candidates from the branch that actually fired into SafetyState. Without this,
-    // a .microBolus tick records programmed=0 against the unused physiologicalTempBasal
-    // candidate and SafetyState.deltaUnits* accumulates a phantom negative delta.
-    @Test func recordZeroesOutUnusedBranchFields() async throws {
+    // `record(decision:candidates:...)` projects each decision form onto the matching
+    // SafetyState.Kind case, dropping the unused form's candidates. This was previously
+    // a "zero out unused branch fields" pattern; making Kind enum-shaped removes the
+    // hazard structurally — cases that don't apply simply don't exist on this state.
+    @Test func recordProjectsDecisionOntoMatchingKind() async throws {
         let safetyService = LocalSafetyService(storedObjectFactory: MockStoredObject.self)
         let startDate = Date.f("2018-07-15 03:34:29 +0000")
         let duration = 30.minutesToSeconds()
 
-        // Both branches' candidates are non-zero, so a leak from the unused branch
-        // would show up as a non-zero stored field.
-        let analysis = SafetyAnalysis(
-            machineLearningTempBasal: 1.3,
+        let candidates = DoseCandidates(
             physiologicalTempBasal: 0.95,
-            machineLearningMicroBolus: 0.3,
+            mlTempBasal: 1.3,
             physiologicalMicroBolus: 0.2,
-            machineLearningInsulinLastThreeHours: 0,
-            biologicalInvariantMgDlPerHour: nil
+            mlMicroBolus: 0.3
         )
 
-        await safetyService.record(at: startDate, decision: .tempBasal(unitsPerHour: 1.5), analysis: analysis, duration: duration)
-        await safetyService.record(at: startDate + 5.minutesToSeconds(), decision: .microBolus(units: 0.3), analysis: analysis, duration: duration)
-        await safetyService.record(at: startDate + 10.minutesToSeconds(), decision: .suspendForBiologicalInvariant(mgDlPerHour: -50), analysis: analysis, duration: duration)
+        await safetyService.record(at: startDate, decision: .tempBasal(unitsPerHour: 1.5), candidates: candidates, duration: duration)
+        await safetyService.record(at: startDate + 5.minutesToSeconds(), decision: .microBolus(units: 0.3), candidates: candidates, duration: duration)
+        await safetyService.record(at: startDate + 10.minutesToSeconds(), decision: .suspendForBiologicalInvariant(mgDlPerHour: -50), candidates: candidates, duration: duration)
 
         let states = await safetyService.safetyStates
         #expect(states.count == 3)
 
-        let tempBasalState = states[0]
-        #expect(tempBasalState.programmedTempBasalUnitsPerHour == 1.5)
-        #expect(tempBasalState.safetyTempBasalUnitsPerHour == 0.95)
-        #expect(tempBasalState.machineLearningTempBasalUnitsPerHour == 1.3)
-        #expect(tempBasalState.programmedMicroBolus == 0)
-        #expect(tempBasalState.safetyMicroBolus == 0)
-        #expect(tempBasalState.machineLearningMicroBolus == 0)
-        #expect(tempBasalState.biologicalInvariantViolation == false)
+        guard case .tempBasal(let basalProgrammed, let basalPhysiological) = states[0].kind else {
+            Issue.record("Expected .tempBasal kind for tempBasal decision; got \(states[0].kind)")
+            return
+        }
+        #expect(basalProgrammed == 1.5)
+        #expect(basalPhysiological == 0.95)
 
-        let microBolusState = states[1]
-        #expect(microBolusState.programmedTempBasalUnitsPerHour == 0)
-        #expect(microBolusState.safetyTempBasalUnitsPerHour == 0)
-        #expect(microBolusState.machineLearningTempBasalUnitsPerHour == 0)
-        #expect(microBolusState.programmedMicroBolus == 0.3)
-        #expect(microBolusState.safetyMicroBolus == 0.2)
-        #expect(microBolusState.machineLearningMicroBolus == 0.3)
-        #expect(microBolusState.biologicalInvariantViolation == false)
+        guard case .microBolus(let bolusProgrammed, let bolusPhysiological) = states[1].kind else {
+            Issue.record("Expected .microBolus kind for microBolus decision; got \(states[1].kind)")
+            return
+        }
+        #expect(bolusProgrammed == 0.3)
+        #expect(bolusPhysiological == 0.2)
 
-        let suspendState = states[2]
-        #expect(suspendState.programmedTempBasalUnitsPerHour == 0)
-        #expect(suspendState.safetyTempBasalUnitsPerHour == 0)
-        #expect(suspendState.machineLearningTempBasalUnitsPerHour == 0)
-        #expect(suspendState.programmedMicroBolus == 0)
-        #expect(suspendState.safetyMicroBolus == 0)
-        #expect(suspendState.machineLearningMicroBolus == 0)
-        #expect(suspendState.biologicalInvariantViolation == true)
+        guard case .suspended = states[2].kind else {
+            Issue.record("Expected .suspended kind for suspend decision; got \(states[2].kind)")
+            return
+        }
     }
 
     @Test func lessInsulinClamp() async {
@@ -195,12 +183,59 @@ struct SafetyServiceTests {
 
         #expect(abs(firstTempBasal.tempBasal - 0.0) <= insulinAccuracy)
 
-        await safetyService.updateAfterProgrammingPump(at: startDate, programmedTempBasalUnitsPerHour: 0, safetyTempBasalUnitsPerHour: 4.0, machineLearningTempBasalUnitsPerHour: 0, duration: 30.minutesToSeconds(), programmedMicroBolus: 0, safetyMicroBolus: 0, machineLearningMicroBolus: 0, biologicalInvariantViolation: false)
+        // programmed=0 against physiological=4.0 → -2.0 U delivered (deficit) over 30 min
+        let candidates = DoseCandidates(physiologicalTempBasal: 4.0, mlTempBasal: 0.0, physiologicalMicroBolus: 0, mlMicroBolus: 0)
+        await safetyService.record(at: startDate, decision: .tempBasal(unitsPerHour: 0), candidates: candidates, duration: 30.minutesToSeconds())
 
         // at this point we have a deficit of 2 units from ML, which is
         // our cap so the system should fall back to the safety tempBasal
         let secondTempBasal = await safetyService.tempBasal(at: startDate + 30.minutesToSeconds(), settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 4.0, machineLearningTempBasalUnitsPerHour: 0.0, duration: 30.minutesToSeconds())
 
         #expect(abs(secondTempBasal.tempBasal - 4.0) <= insulinAccuracy)
+    }
+
+    // A `.suspended` tick must contribute 0 to the historical ML insulin tally,
+    // even when the candidates passed alongside it are non-trivial. Otherwise a
+    // biological-invariant suspension would spuriously fill the budget and clamp
+    // legitimate ML deviations on the next tick.
+    @Test func suspendedTickContributesZeroToMlBudget() async {
+        let safetyService = LocalSafetyService(storedObjectFactory: MockStoredObject.self)
+        let settings = await MockSettingsStorage()
+        await settings.update(pumpBasalRateUnitsPerHour: 2.0 / 3)
+        let startDate = Date.f("2018-07-15 03:34:29 +0000")
+
+        // Non-trivial candidates: a buggy `.suspended` path could read these and
+        // accumulate phantom delta. Correct behavior ignores them entirely.
+        let candidates = DoseCandidates(physiologicalTempBasal: 0, mlTempBasal: 3.0, physiologicalMicroBolus: 0, mlMicroBolus: 0.5)
+
+        await safetyService.record(at: startDate, decision: .suspendForBiologicalInvariant(mgDlPerHour: -50), candidates: candidates, duration: 30.minutesToSeconds())
+
+        // With historicalMlInsulin=0, requesting ml=3.0 vs safety=1.0 over 30 min
+        // (delta = 1.0 U) sits well inside the 2.0 U / 3-hour budget — should pass through unchanged.
+        let result = await safetyService.tempBasal(at: startDate + 5.minutesToSeconds(), settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
+
+        #expect(abs(result.tempBasal - 3.0) <= insulinAccuracy)
+    }
+
+    // Mirrors `extraInsulinClamp` but isolated to the microBolus path. Two boluses
+    // each 1 U over physiological exhaust the 2 U / 3-hour cap; the next ML temp
+    // basal request must clamp back to safety.
+    @Test func microBolusOnlyExhaustsMlBudgetThenClamps() async {
+        let safetyService = LocalSafetyService(storedObjectFactory: MockStoredObject.self)
+        let settings = await MockSettingsStorage()
+        await settings.update(pumpBasalRateUnitsPerHour: 2.0 / 3)
+        let startDate = Date.f("2018-07-15 03:34:29 +0000")
+
+        let candidates = DoseCandidates(physiologicalTempBasal: 0, mlTempBasal: 0, physiologicalMicroBolus: 0.1, mlMicroBolus: 1.1)
+
+        // Two micro-boluses, each 1.0 U over physiological → 2.0 U total ML credit consumed
+        await safetyService.record(at: startDate, decision: .microBolus(units: 1.1), candidates: candidates, duration: 30.minutesToSeconds())
+        await safetyService.record(at: startDate + 5.minutesToSeconds(), decision: .microBolus(units: 1.1), candidates: candidates, duration: 30.minutesToSeconds())
+
+        // ML wants 3.0, safety wants 1.0. Budget exhausted, so the upper clamp
+        // forces deltaUnits → 0 and the result lands at safety.
+        let result = await safetyService.tempBasal(at: startDate + 10.minutesToSeconds(), settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
+
+        #expect(abs(result.tempBasal - 1.0) <= insulinAccuracy)
     }
 }

--- a/ios/BioKernel/BioKernelTests/SafetyStateCodableTests.swift
+++ b/ios/BioKernel/BioKernelTests/SafetyStateCodableTests.swift
@@ -1,0 +1,129 @@
+//
+//  SafetyStateCodableTests.swift
+//  BioKernelTests
+//
+//  Round-trip tests for SafetyState's Codable conformance. The Kind enum has
+//  associated values, which is the shape that previously surfaced "_0" key bugs
+//  for LoopOutcome — this guards SafetyState against the same regression and
+//  the silent failure mode where post-restart decoding falls back to [] and the
+//  3-hour ML budget tally invisibly resets.
+//
+
+import Testing
+import Foundation
+
+@testable import BioKernel
+
+struct SafetyStateCodableTests {
+    private let referenceAt = Date(timeIntervalSince1970: 1_777_687_460)
+    private let referenceDuration: TimeInterval = 30 * 60
+
+    private func makeState(kind: SafetyState.Kind) -> SafetyState {
+        return SafetyState(at: referenceAt, duration: referenceDuration, kind: kind)
+    }
+
+    private func roundTrip(_ state: SafetyState) throws -> (firstJson: String, decoded: SafetyState, secondJson: String) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data1 = try encoder.encode(state)
+        let json1 = try #require(String(data: data1, encoding: .utf8))
+
+        let decoded = try JSONDecoder().decode(SafetyState.self, from: data1)
+
+        let data2 = try encoder.encode(decoded)
+        let json2 = try #require(String(data: data2, encoding: .utf8))
+        return (json1, decoded, json2)
+    }
+
+    @Test func tempBasalRoundTrip() throws {
+        let state = makeState(kind: .tempBasal(programmed: 1.5, physiological: 0.95))
+        let (json1, decoded, json2) = try roundTrip(state)
+
+        #expect(!json1.contains("\"_0\""), "encoded JSON should not contain _0 keys: \(json1)")
+        #expect(json1.contains("\"tempBasal\""))
+        #expect(json1 == json2, "round-trip JSON should be byte-identical")
+
+        guard case .tempBasal(let programmed, let physiological) = decoded.kind else {
+            Issue.record("decoded kind should be .tempBasal; got \(decoded.kind)")
+            return
+        }
+        #expect(programmed == 1.5)
+        #expect(physiological == 0.95)
+        #expect(decoded.at == state.at)
+        #expect(decoded.duration == state.duration)
+    }
+
+    @Test func microBolusRoundTrip() throws {
+        let state = makeState(kind: .microBolus(programmed: 0.3, physiological: 0.2))
+        let (json1, decoded, json2) = try roundTrip(state)
+
+        #expect(!json1.contains("\"_0\""), "encoded JSON should not contain _0 keys: \(json1)")
+        #expect(json1.contains("\"microBolus\""))
+        #expect(json1 == json2, "round-trip JSON should be byte-identical")
+
+        guard case .microBolus(let programmed, let physiological) = decoded.kind else {
+            Issue.record("decoded kind should be .microBolus; got \(decoded.kind)")
+            return
+        }
+        #expect(programmed == 0.3)
+        #expect(physiological == 0.2)
+        #expect(decoded.at == state.at)
+        #expect(decoded.duration == state.duration)
+    }
+
+    @Test func suspendedRoundTrip() throws {
+        let state = makeState(kind: .suspended)
+        let (json1, decoded, json2) = try roundTrip(state)
+
+        #expect(!json1.contains("\"_0\""), "encoded JSON should not contain _0 keys: \(json1)")
+        #expect(json1.contains("\"suspended\""))
+        #expect(json1 == json2, "round-trip JSON should be byte-identical")
+
+        guard case .suspended = decoded.kind else {
+            Issue.record("decoded kind should be .suspended; got \(decoded.kind)")
+            return
+        }
+        #expect(decoded.at == state.at)
+        #expect(decoded.duration == state.duration)
+    }
+
+    // Mirrors what `safety_states.json` actually persists: an ordered array of
+    // mixed-kind entries. Catches regressions where a single Kind round-trips
+    // but the array shape doesn't.
+    @Test func arrayRoundTripPreservesAllKinds() throws {
+        let states: [SafetyState] = [
+            makeState(kind: .tempBasal(programmed: 1.5, physiological: 0.95)),
+            makeState(kind: .microBolus(programmed: 0.3, physiological: 0.2)),
+            makeState(kind: .suspended)
+        ]
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(states)
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        #expect(!json.contains("\"_0\""), "encoded JSON should not contain _0 keys: \(json)")
+
+        let decoded = try JSONDecoder().decode([SafetyState].self, from: data)
+        #expect(decoded.count == 3)
+
+        guard case .tempBasal(let p1, let phy1) = decoded[0].kind else {
+            Issue.record(".tempBasal didn't survive array round-trip; got \(decoded[0].kind)")
+            return
+        }
+        #expect(p1 == 1.5)
+        #expect(phy1 == 0.95)
+
+        guard case .microBolus(let p2, let phy2) = decoded[1].kind else {
+            Issue.record(".microBolus didn't survive array round-trip; got \(decoded[1].kind)")
+            return
+        }
+        #expect(p2 == 0.3)
+        #expect(phy2 == 0.2)
+
+        guard case .suspended = decoded[2].kind else {
+            Issue.record(".suspended didn't survive array round-trip; got \(decoded[2].kind)")
+            return
+        }
+    }
+}

--- a/ios/BioKernel/BioKernelTests/Utils/MockClasses.swift
+++ b/ios/BioKernel/BioKernelTests/Utils/MockClasses.swift
@@ -125,9 +125,9 @@ class MockSafetyService: SafetyService {
     func tempBasal(at: Date, settings: CodableSettings, safetyTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval) async -> BioKernel.SafetyTempBasal {
         return SafetyTempBasal(tempBasal: 0, machineLearningInsulinLastThreeHours: 0)
     }
-    
-    func updateAfterProgrammingPump(at: Date, programmedTempBasalUnitsPerHour: Double, safetyTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval, programmedMicroBolus: Double, safetyMicroBolus: Double, machineLearningMicroBolus: Double, biologicalInvariantViolation: Bool) async {
-        
+
+    func record(at: Date, decision: DosingDecision, candidates: DoseCandidates, duration: TimeInterval) async {
+
     }
 }
 


### PR DESCRIPTION
This commit moves our SafetyState struct to an enum-style to avoid
some of the confusing logic we had previously over zeroing out temp
basal / micro bolus values depending on which one was picked by the
dosing logic. It also includes a new more intuitive value for
capturing ML and phyiological dosing candidates.

Important: This commit will change the closed loop and safety on-disk
structures, so it will reset both when installed.
