### PR TITLE
Persist PID state

### DIFF
--- a/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
+++ b/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		3B5076392F92F77400E5D3A6 /* PushNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5076382F92F77400E5D3A6 /* PushNotificationService.swift */; };
 		3B50774C2F93DAB800E5D3A6 /* DosingDecisionTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B50774B2F93DAB800E5D3A6 /* DosingDecisionTestHelpers.swift */; };
 		3B5329502B5D8451000DED1A /* AddedGlucoseDataFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B53294F2B5D8451000DED1A /* AddedGlucoseDataFrame.swift */; };
+		3B5361732FA6ABB500E98A24 /* PhysiologicalModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5361722FA6ABB500E98A24 /* PhysiologicalModelsTests.swift */; };
 		3B6063B02B54BDA9009D9CBC /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6063AF2B54BDA9009D9CBC /* SettingsViewModel.swift */; };
 		3B6063B22B54BDB7009D9CBC /* DecimalPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6063B12B54BDB7009D9CBC /* DecimalPicker.swift */; };
 		3B6063B42B54BDFA009D9CBC /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6063B32B54BDFA009D9CBC /* SettingsView.swift */; };
@@ -247,6 +248,7 @@
 		3B5076382F92F77400E5D3A6 /* PushNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationService.swift; sourceTree = "<group>"; };
 		3B50774B2F93DAB800E5D3A6 /* DosingDecisionTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DosingDecisionTestHelpers.swift; sourceTree = "<group>"; };
 		3B53294F2B5D8451000DED1A /* AddedGlucoseDataFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddedGlucoseDataFrame.swift; sourceTree = "<group>"; };
+		3B5361722FA6ABB500E98A24 /* PhysiologicalModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysiologicalModelsTests.swift; sourceTree = "<group>"; };
 		3B6063AF2B54BDA9009D9CBC /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		3B6063B12B54BDB7009D9CBC /* DecimalPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecimalPicker.swift; sourceTree = "<group>"; };
 		3B6063B32B54BDFA009D9CBC /* SettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -643,12 +645,13 @@
 			children = (
 				3BA00A562D231CA00002B051 /* ClosedLoopSafetyTests.swift */,
 				3B7F08402B2DDE33002930A4 /* ClosedLoopTests.swift */,
+				3CBFB9892AFE02E90020FC90 /* InsulinOnBoardTests.swift */,
 				3CAAFC8D2B0D739200597055 /* InsulinPersistentStorageTests.swift */,
 				3B7C6D9B2B0C09320030DFA7 /* InsulinStorageTests.swift */,
-				3CBFB9892AFE02E90020FC90 /* InsulinOnBoardTests.swift */,
 				3B40DE682D24453F0032328F /* LoopFunctionTests.swift */,
 				3B016DD92FA64E720011F6EC /* LoopOutcomeCodableTests.swift */,
 				3B40DE662D243C6C0032328F /* MicroBolusAmountTest.swift */,
+				3B5361722FA6ABB500E98A24 /* PhysiologicalModelsTests.swift */,
 				3B348DAD2B5DAFB0000A40E9 /* SafetyServiceTests.swift */,
 				3B87043F2FA68DF60005DDE0 /* SafetyStateCodableTests.swift */,
 				3C15FE482B0C9C5000CA1FD4 /* Resources */,
@@ -954,6 +957,7 @@
 				3BCL5T01000000000000A001 /* ClosedLoopTestSupport.swift in Sources */,
 				3CAAFC902B0D73C400597055 /* MockClasses.swift in Sources */,
 				3BA00A572D231CA00002B051 /* ClosedLoopSafetyTests.swift in Sources */,
+				3B5361732FA6ABB500E98A24 /* PhysiologicalModelsTests.swift in Sources */,
 				3B348DAE2B5DAFB0000A40E9 /* SafetyServiceTests.swift in Sources */,
 				3CAAFC8E2B0D739200597055 /* InsulinPersistentStorageTests.swift in Sources */,
 				3B40DE672D243C6C0032328F /* MicroBolusAmountTest.swift in Sources */,

--- a/ios/BioKernel/BioKernel/DependencyInjection/AppComposition.swift
+++ b/ios/BioKernel/BioKernel/DependencyInjection/AppComposition.swift
@@ -102,6 +102,7 @@ final class AppComposition {
 
         // Tier 2 — physiology depends on storages
         let physiologicalModels = LocalPhysiologicalModels(
+            storedObjectFactory: storedObjectFactory,
             glucoseStorage: glucoseStorage,
             insulinStorage: insulinStorage
         )

--- a/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
+++ b/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
@@ -46,6 +46,21 @@ public protocol PhysiologicalModels {
     func deltaGlucoseError(settings: CodableSettings, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> Double?
 }
 
+/// Live PID controller state that survives app restart. The same numbers are
+/// also captured per-loop inside `PIDTempBasalResult` (in `closed_loop_results.json`)
+/// for diagnostics, but this file is the source of truth the controller resumes
+/// from. `savedAt` drives the staleness check in `LocalPhysiologicalModels`: if
+/// the next `tempBasal` runs `staleStateThreshold` or more after `savedAt`, the
+/// integrator and filter are reset to defaults rather than resumed from a stale
+/// snapshot.
+struct PIDState: Codable {
+    let savedAt: Date
+    let lastGlucose: Double?
+    let lastGlucoseAt: Date?
+    let accumulatedError: Double
+    let lastFilteredGlucose: Double?
+}
+
 struct PhysiologicalUtilities {
     static func calculateBasalBaselineInsulinOnBoard(basalRate: Double, insulinType: InsulinType) -> Double {
         let now = Date()
@@ -56,12 +71,25 @@ struct PhysiologicalUtilities {
 }
 
 actor LocalPhysiologicalModels: PhysiologicalModels {
+    static let staleStateThreshold: TimeInterval = 23 * 60
+
     private let glucoseStorage: GlucoseStorage
     private let insulinStorage: InsulinStorage
+    private let stateStorage: StoredObject
+    private var lastSavedAt: Date?
 
-    init(glucoseStorage: GlucoseStorage, insulinStorage: InsulinStorage) {
+    init(storedObjectFactory: StoredObject.Type, glucoseStorage: GlucoseStorage, insulinStorage: InsulinStorage) {
         self.glucoseStorage = glucoseStorage
         self.insulinStorage = insulinStorage
+        let stateStorage = storedObjectFactory.create(fileName: "pid_state.json")
+        self.stateStorage = stateStorage
+        if let restored: PIDState = try? stateStorage.read() {
+            self.lastGlucose = restored.lastGlucose
+            self.lastGlucoseAt = restored.lastGlucoseAt
+            self.accumulatedError = restored.accumulatedError
+            self.lastFilteredGlucose = restored.lastFilteredGlucose
+            self.lastSavedAt = restored.savedAt
+        }
     }
 
     func predictGlucoseIn15Minutes(from now: Date) async -> Double? {
@@ -132,6 +160,9 @@ actor LocalPhysiologicalModels: PhysiologicalModels {
     }
     
     func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> PIDTempBasalResult {
+        if let lastSavedAt, at.timeIntervalSince(lastSavedAt) >= Self.staleStateThreshold {
+            resetPidState()
+        }
         let insulinSensitivity = settings.learnedInsulinSensitivity(at: at)
         let correctionDuration = settings.correctionDurationInSeconds
         let basalRate = settings.learnedBasalRate(at: at)
@@ -182,7 +213,31 @@ actor LocalPhysiologicalModels: PhysiologicalModels {
         lastGlucose = glucoseInMgDl
         lastGlucoseAt = at
         lastFilteredGlucose = filteredGlucose
-        
+        persistState(at: at)
+
         return result
+    }
+
+    private func resetPidState() {
+        lastGlucose = nil
+        lastGlucoseAt = nil
+        accumulatedError = 0.0
+        lastFilteredGlucose = nil
+    }
+
+    private func persistState(at: Date) {
+        lastSavedAt = at
+        let state = PIDState(
+            savedAt: at,
+            lastGlucose: lastGlucose,
+            lastGlucoseAt: lastGlucoseAt,
+            accumulatedError: accumulatedError,
+            lastFilteredGlucose: lastFilteredGlucose
+        )
+        do {
+            try stateStorage.write(state)
+        } catch {
+            print("Failed to write PID state: \(error)")
+        }
     }
 }

--- a/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
+++ b/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
@@ -160,7 +160,7 @@ actor LocalPhysiologicalModels: PhysiologicalModels {
     }
     
     func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date) async -> PIDTempBasalResult {
-        if let lastSavedAt, at.timeIntervalSince(lastSavedAt) >= Self.staleStateThreshold {
+        if let lastSavedAt, at.timeIntervalSince(lastSavedAt) >= Self.staleStateThreshold || at < lastSavedAt {
             resetPidState()
         }
         let insulinSensitivity = settings.learnedInsulinSensitivity(at: at)

--- a/ios/BioKernel/BioKernelTests/PhysiologicalModelsTests.swift
+++ b/ios/BioKernel/BioKernelTests/PhysiologicalModelsTests.swift
@@ -1,0 +1,223 @@
+//
+//  PhysiologicalModelsTests.swift
+//  BioKernelTests
+//
+
+import Testing
+import Foundation
+import LoopKit
+@testable import BioKernel
+
+@MainActor
+struct PhysiologicalModelsTests {
+    let now = Date.f("2024-01-15 10:30:00 +0000")
+    let settings: MockSettingsStorage
+
+    init() {
+        InMemoryStoredObject.reset()
+        settings = MockSettingsStorage()
+    }
+
+    @Test func coldStartHasNoPriorGlucose() async throws {
+        let physModels = LocalPhysiologicalModels(
+            storedObjectFactory: InMemoryStoredObject.self,
+            glucoseStorage: MockGlucoseStorage(),
+            insulinStorage: MockInsulinStorage()
+        )
+
+        let result = await physModels.tempBasal(
+            settings: settings.snapshot(),
+            glucoseInMgDl: 120,
+            targetGlucoseInMgDl: 90,
+            insulinOnBoard: 0,
+            dataFrame: nil,
+            at: now
+        )
+
+        #expect(result.lastGlucose == nil)
+        #expect(result.lastGlucoseAt == nil)
+        #expect(result.derivative == 0.0)
+        #expect(result.accumulatedError == 0.0)
+    }
+
+    @Test func tempBasalPersistsStateToStorage() async throws {
+        let physModels = LocalPhysiologicalModels(
+            storedObjectFactory: InMemoryStoredObject.self,
+            glucoseStorage: MockGlucoseStorage(),
+            insulinStorage: MockInsulinStorage()
+        )
+
+        _ = await physModels.tempBasal(
+            settings: settings.snapshot(),
+            glucoseInMgDl: 120,
+            targetGlucoseInMgDl: 90,
+            insulinOnBoard: 0,
+            dataFrame: nil,
+            at: now
+        )
+
+        let persisted: PIDState? = try InMemoryStoredObject.read(fileName: "pid_state.json")
+        #expect(persisted != nil)
+        #expect(persisted?.savedAt == now)
+        #expect(persisted?.lastGlucose == 120)
+        #expect(persisted?.lastGlucoseAt == now)
+        #expect(persisted?.accumulatedError == 0.0)
+        // lowPassFilter returns the raw value on cold start
+        #expect(persisted?.lastFilteredGlucose == 120)
+    }
+
+    @Test func newInstanceRestoresPriorPidState() async throws {
+        // First "boot" runs once and persists to the shared in-memory storage.
+        let firstBoot = LocalPhysiologicalModels(
+            storedObjectFactory: InMemoryStoredObject.self,
+            glucoseStorage: MockGlucoseStorage(),
+            insulinStorage: MockInsulinStorage()
+        )
+        _ = await firstBoot.tempBasal(
+            settings: settings.snapshot(),
+            glucoseInMgDl: 120,
+            targetGlucoseInMgDl: 90,
+            insulinOnBoard: 0,
+            dataFrame: nil,
+            at: now
+        )
+
+        // Second "boot" — fresh actor sharing the same storage.
+        let secondBoot = LocalPhysiologicalModels(
+            storedObjectFactory: InMemoryStoredObject.self,
+            glucoseStorage: MockGlucoseStorage(),
+            insulinStorage: MockInsulinStorage()
+        )
+        let nextReadingAt = now + 5.minutesToSeconds()
+        let result = await secondBoot.tempBasal(
+            settings: settings.snapshot(),
+            glucoseInMgDl: 130,
+            targetGlucoseInMgDl: 90,
+            insulinOnBoard: 0,
+            dataFrame: nil,
+            at: nextReadingAt
+        )
+
+        // Result reports the *prior* glucose (the one persisted from the first boot).
+        #expect(result.lastGlucose == 120)
+        #expect(result.lastGlucoseAt == now)
+        // 5-minute gap is inside the 11-minute dt guard, so derivative is non-zero.
+        #expect(result.derivative != 0.0)
+    }
+
+    @Test func staleRestoredStateResetsToDefaults() async throws {
+        // Pre-seed storage with state savedAt 30 minutes ago — past the 23-min
+        // staleness threshold. The next tempBasal call should reset the
+        // controller to defaults rather than resume from the stale snapshot.
+        let staleAt = now - 30.minutesToSeconds()
+        let stale = PIDState(
+            savedAt: staleAt,
+            lastGlucose: 110,
+            lastGlucoseAt: staleAt,
+            accumulatedError: 50,
+            lastFilteredGlucose: 110
+        )
+        try InMemoryStoredObject.write(stale, fileName: "pid_state.json")
+
+        let physModels = LocalPhysiologicalModels(
+            storedObjectFactory: InMemoryStoredObject.self,
+            glucoseStorage: MockGlucoseStorage(),
+            insulinStorage: MockInsulinStorage()
+        )
+
+        let result = await physModels.tempBasal(
+            settings: settings.snapshot(),
+            glucoseInMgDl: 130,
+            targetGlucoseInMgDl: 90,
+            insulinOnBoard: 0,
+            dataFrame: nil,
+            at: now
+        )
+
+        // Stale state was wiped before the call ran ⇒ behaves like cold start.
+        #expect(result.lastGlucose == nil)
+        #expect(result.lastGlucoseAt == nil)
+        #expect(result.accumulatedError == 0.0)
+        #expect(result.derivative == 0.0)
+    }
+
+    @Test func freshRestoredStateIsKept() async throws {
+        // savedAt 22 minutes ago — just inside the 23-min staleness threshold.
+        // State should survive the restore. The 11-min `dt` guard still skips
+        // derivative/integrator updates on this single call, but the prior
+        // values themselves stay intact.
+        let savedAt = now - 22.minutesToSeconds()
+        let fresh = PIDState(
+            savedAt: savedAt,
+            lastGlucose: 110,
+            lastGlucoseAt: savedAt,
+            accumulatedError: 50,
+            lastFilteredGlucose: 110
+        )
+        try InMemoryStoredObject.write(fresh, fileName: "pid_state.json")
+
+        let physModels = LocalPhysiologicalModels(
+            storedObjectFactory: InMemoryStoredObject.self,
+            glucoseStorage: MockGlucoseStorage(),
+            insulinStorage: MockInsulinStorage()
+        )
+
+        let result = await physModels.tempBasal(
+            settings: settings.snapshot(),
+            glucoseInMgDl: 130,
+            targetGlucoseInMgDl: 90,
+            insulinOnBoard: 0,
+            dataFrame: nil,
+            at: now
+        )
+
+        #expect(result.lastGlucose == 110)
+        #expect(result.lastGlucoseAt == savedAt)
+        #expect(result.accumulatedError == 50)
+        #expect(result.derivative == 0.0)
+    }
+}
+
+// MARK: - In-memory persisting StoredObject for tests
+
+/// Test double for `StoredObject` whose backing storage is shared across all
+/// instances with the same fileName. Lets a test simulate "app restart" by
+/// constructing a fresh actor with the same factory type and seeing the prior
+/// writes.
+final class InMemoryStoredObject: StoredObject {
+    nonisolated(unsafe) private static var blobs: [String: Data] = [:]
+    private let fileName: String
+
+    private init(fileName: String) {
+        self.fileName = fileName
+    }
+
+    static func create(fileName: String) -> BioKernel.StoredObject {
+        return InMemoryStoredObject(fileName: fileName)
+    }
+
+    static func reset() {
+        blobs.removeAll()
+    }
+
+    static func read<T: Decodable>(fileName: String) throws -> T? {
+        guard let data = blobs[fileName] else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        return try decoder.decode(T.self, from: data)
+    }
+
+    static func write<T: Encodable>(_ object: T, fileName: String) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        blobs[fileName] = try encoder.encode(object)
+    }
+
+    func read<T>() throws -> T? where T : Decodable {
+        return try Self.read(fileName: fileName)
+    }
+
+    func write<T>(_ object: T) throws where T : Encodable {
+        try Self.write(object, fileName: fileName)
+    }
+}

--- a/ios/BioKernel/BioKernelTests/Utils/ClosedLoopTestSupport.swift
+++ b/ios/BioKernel/BioKernelTests/Utils/ClosedLoopTestSupport.swift
@@ -17,7 +17,7 @@ func makeClosedLoopService(
     safetyService: SafetyService = MockSafetyService()
 ) -> LoopRunner {
     let physModels = physiologicalModels
-        ?? LocalPhysiologicalModels(glucoseStorage: glucoseStorage, insulinStorage: insulinStorage)
+        ?? LocalPhysiologicalModels(storedObjectFactory: MockStoredObject.self, glucoseStorage: glucoseStorage, insulinStorage: insulinStorage)
     return LoopRunner(
         storedObjectFactory: MockStoredObject.self,
         glucoseStorage: glucoseStorage,


### PR DESCRIPTION
This commit adds storage for the PID algorithm. Previously it stored
state in memory, so if the OS killed the process it would reset its
low-pass filter and accumulator state. With this udpate we now persist
this data with each loop.
