### PR TITLE
add staleness indicator to watch app

### DIFF
--- a/ios/BioKernel/BioKernelTests/PhysiologicalModelsTests.swift
+++ b/ios/BioKernel/BioKernelTests/PhysiologicalModelsTests.swift
@@ -9,6 +9,7 @@ import LoopKit
 @testable import BioKernel
 
 @MainActor
+@Suite(.serialized)
 struct PhysiologicalModelsTests {
     let now = Date.f("2024-01-15 10:30:00 +0000")
     let settings: MockSettingsStorage

--- a/ios/BioKernel/BioKernelWatch Watch App/GlucoseView.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/GlucoseView.swift
@@ -9,52 +9,61 @@ import SwiftUI
 
 struct GlucoseView: View {
     @EnvironmentObject var stateViewModel: StateViewModel
-    
+
     var body: some View {
-        VStack {
-            HStack {
-                VStack {
-                    Text("IoB").font(.caption)
-                    if let iob = stateViewModel.appState?.insulinOnBoard, iob > 0.05 {
-                        Text(String(format: "%0.1f", iob))
-                            .font(.title3)
-                            .foregroundColor(.blue)
-                    } else {
-                        Text("-")
-                            .font(.title3)
-                            .foregroundColor(.blue)
+        TimelineView(.periodic(from: .now, by: 60)) { context in
+            VStack {
+                HStack {
+                    VStack {
+                        Text("IoB").font(.caption)
+                        if let iob = stateViewModel.appState?.insulinOnBoard, iob > 0.05 {
+                            Text(String(format: "%0.1f", iob))
+                                .font(.title3)
+                                .foregroundColor(.blue)
+                        } else {
+                            Text("-")
+                                .font(.title3)
+                                .foregroundColor(.blue)
+                        }
                     }
-                }
-                .frame(maxWidth: .infinity)
-                VStack {
-                    if let glucose = stateViewModel.appState?.glucoseReadings.last {
-                        let trend = glucose.trend ?? ""
-                        Text("\(String(format: "%0.0f", glucose.glucoseReadingInMgDl))\(trend)")
-                            .font(.title2)
-                            .minimumScaleFactor(0.3)
-                            .lineLimit(1)
-                    } else {
-                        Text("-").font(.title2)
+                    .frame(maxWidth: .infinity)
+                    VStack {
+                        if let glucose = stateViewModel.appState?.glucoseReadings.last,
+                           let minutes = stateViewModel.appState?.minutesSinceLastReading(now: context.date) {
+                            let trend = glucose.trend ?? ""
+                            Text("\(String(format: "%0.0f", glucose.glucoseReadingInMgDl))\(trend)")
+                                .font(.title2)
+                                .minimumScaleFactor(0.3)
+                                .lineLimit(1)
+                            Text("\(minutes)m")
+                                .font(.system(size: 10))
+                                .padding(.horizontal, 4)
+                                .padding(.vertical, 1)
+                                .background(stateViewModel.appState?.readingAgeColor(now: context.date) ?? .red)
+                                .cornerRadius(3)
+                        } else {
+                            Text("-").font(.title2)
+                            Text("mg/dl").font(.system(size: 10))
+                        }
                     }
-                    Text("mg/dl").font(.system(size: 10))
-                }
-                .frame(maxWidth: .infinity)
-                VStack {
-                    Text("Pred").font(.caption)
-                    if let prediction = stateViewModel.appState?.predictedGlucose, let isPredictedGlucoseInRange = stateViewModel.appState?.isPredictedGlucoseInRange {
-                        let color: Color = isPredictedGlucoseInRange ? .blue : .yellow
-                        Text("\(String(format: "%0.0f", prediction))")
-                            .font(.title3)
-                            .foregroundColor(color)
-                    } else {
-                        Text("-")
-                            .font(.title3)
-                            .foregroundColor(.blue)
+                    .frame(maxWidth: .infinity)
+                    VStack {
+                        Text("Pred").font(.caption)
+                        if let prediction = stateViewModel.appState?.predictedGlucose, let isPredictedGlucoseInRange = stateViewModel.appState?.isPredictedGlucoseInRange {
+                            let color: Color = isPredictedGlucoseInRange ? .blue : .yellow
+                            Text("\(String(format: "%0.0f", prediction))")
+                                .font(.title3)
+                                .foregroundColor(color)
+                        } else {
+                            Text("-")
+                                .font(.title3)
+                                .foregroundColor(.blue)
+                        }
                     }
+                    .frame(maxWidth: .infinity)
                 }
                 .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
         }
     }
 }

--- a/ios/BioKernel/BioKernelWatch Watch App/StateViewModel.swift
+++ b/ios/BioKernel/BioKernelWatch Watch App/StateViewModel.swift
@@ -34,13 +34,13 @@ class StateViewModel: ObservableObject, SessionUpdateDelegate {
 }
 
 extension BioKernelState {
-    func minutesSinceLastReading() -> Int? {
+    func minutesSinceLastReading(now: Date = Date()) -> Int? {
         guard let lastUpdate = self.glucoseReadings.last?.at else { return nil }
-        return Int(Date().timeIntervalSince(lastUpdate).secondsToMinutes())
+        return Int(now.timeIntervalSince(lastUpdate).secondsToMinutes())
     }
-    
-    func readingAgeColor() -> Color {
-        guard let minutesSinceLastReading = minutesSinceLastReading() else { return .red }
+
+    func readingAgeColor(now: Date = Date()) -> Color {
+        guard let minutesSinceLastReading = minutesSinceLastReading(now: now) else { return .red }
         if minutesSinceLastReading < 6 {
             return .green
         } else if minutesSinceLastReading < 12 {


### PR DESCRIPTION
This PR adds a small visual component to the main view in the watch app to let people know when the data is stale. This UI/UX is similar to how we handle the watch app during exercise mode. This PR also includes a unit test fix that is unrelated to the code in this PR.