### PR TITLE
Refactor variables named safety

### DIFF
--- a/ios/BioKernel/BioKernel/DataTypes/ClosedLoopDataTypes.swift
+++ b/ios/BioKernel/BioKernel/DataTypes/ClosedLoopDataTypes.swift
@@ -334,7 +334,7 @@ struct DosingPipeline {
         let mlDuration = Date().timeIntervalSince(mlStart)
 
         let safetyStart = Date()
-        let safetyTempBasalResult = await safety.tempBasal(at: at, settings: settings, safetyTempBasalUnitsPerHour: physiologicalTempBasal, machineLearningTempBasalUnitsPerHour: mlTempBasal, duration: settings.correctionDurationInSeconds)
+        let safetyTempBasalResult = await safety.tempBasal(at: at, settings: settings, reactiveSafeTempBasalUnitsPerHour: physiologicalTempBasal, machineLearningTempBasalUnitsPerHour: mlTempBasal, duration: settings.correctionDurationInSeconds)
         let safetyTempBasal = guardrails.clamp(safetyTempBasalResult.tempBasal)
         let safetyDuration = Date().timeIntervalSince(safetyStart)
 

--- a/ios/BioKernel/BioKernel/Services/SafetyService.swift
+++ b/ios/BioKernel/BioKernel/Services/SafetyService.swift
@@ -9,7 +9,7 @@ import Foundation
 import LoopKit
 
 public protocol SafetyService {
-    func tempBasal(at: Date, settings: CodableSettings, safetyTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval) async -> SafetyTempBasal
+    func tempBasal(at: Date, settings: CodableSettings, reactiveSafeTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval) async -> SafetyTempBasal
     func record(at: Date, decision: DosingDecision, candidates: DoseCandidates, duration: TimeInterval) async
 }
 
@@ -70,8 +70,8 @@ actor LocalSafetyService: SafetyService {
     
     // Note: we ignore actual insulin delivered and use the
     // programmed values for the safety service
-    func tempBasal(at: Date, settings: CodableSettings, safetyTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval) async ->  SafetyTempBasal {
-        
+    func tempBasal(at: Date, settings: CodableSettings, reactiveSafeTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval) async ->  SafetyTempBasal {
+
         let start = at - timeHorizon
         let events = safetyStates.filter { $0.at >= (start - duration) && $0.at < at }
 
@@ -80,26 +80,26 @@ actor LocalSafetyService: SafetyService {
         for (event, nextTime) in zip(events, nextTimes) {
             historicalMlInsulin += event.deltaUnitsDeliveredByMachineLearning(from: start, to: nextTime)
         }
-                
+
         // convert tempBasal rates to units of insulin, assuming it runs for the entire duration
         let mlTempBasalUnits = machineLearningTempBasalUnitsPerHour * duration / 1.hoursToSeconds()
-        let safetyTempBasalUnits = safetyTempBasalUnitsPerHour * duration / 1.hoursToSeconds()
-        
+        let reactiveSafeTempBasalUnits = reactiveSafeTempBasalUnitsPerHour * duration / 1.hoursToSeconds()
+
         // calculate our bounds based on the basal rate
         let safetyBounds = settings.maxBasalRate() * timeHorizon / 1.hoursToSeconds()
         let upperBoundInsulinUnits = safetyBounds
         let lowerBoundInsulinUnits = -safetyBounds
-        
+
         // make sure that the upperBound doesn't go below 0
         // and that the lowerBound doesn't go above 0
         let upperBound = max(upperBoundInsulinUnits - historicalMlInsulin, 0)
         let lowerBound = min(lowerBoundInsulinUnits - historicalMlInsulin, 0)
-        let deltaUnits = (mlTempBasalUnits - safetyTempBasalUnits).clamp(low: lowerBound, high: upperBound)
+        let deltaUnits = (mlTempBasalUnits - reactiveSafeTempBasalUnits).clamp(low: lowerBound, high: upperBound)
 
         // now convert units back to tempBasal and add it to our safety value
         let deltaTempBasal = deltaUnits * 1.hoursToSeconds() / duration
-        
-        return SafetyTempBasal(tempBasal: safetyTempBasalUnitsPerHour + deltaTempBasal, machineLearningInsulinLastThreeHours: historicalMlInsulin)
+
+        return SafetyTempBasal(tempBasal: reactiveSafeTempBasalUnitsPerHour + deltaTempBasal, machineLearningInsulinLastThreeHours: historicalMlInsulin)
     }
     
     func record(at: Date, decision: DosingDecision, candidates: DoseCandidates, duration: TimeInterval) async {

--- a/ios/BioKernel/BioKernel/Services/SafetyService.swift
+++ b/ios/BioKernel/BioKernel/Services/SafetyService.swift
@@ -96,6 +96,11 @@ actor LocalSafetyService: SafetyService {
         let lowerBound = min(lowerBoundInsulinUnits - historicalMlInsulin, 0)
         let deltaUnits = (mlTempBasalUnits - reactiveSafeTempBasalUnits).clamp(low: lowerBound, high: upperBound)
 
+        // avoid divide by 0 possibility by falling back to the reactive safe model
+        guard duration > 0 else {
+            return SafetyTempBasal(tempBasal: reactiveSafeTempBasalUnitsPerHour, machineLearningInsulinLastThreeHours: historicalMlInsulin)
+        }
+        
         // now convert units back to tempBasal and add it to our safety value
         let deltaTempBasal = deltaUnits * 1.hoursToSeconds() / duration
 

--- a/ios/BioKernel/BioKernel/ViewModels/SettingsViewModel.swift
+++ b/ios/BioKernel/BioKernel/ViewModels/SettingsViewModel.swift
@@ -50,7 +50,7 @@ public class SettingsViewModel: ObservableObject {
     let maxBasalRateValues = stride(from: 0.5, through: 30.0, by: 0.5).map { DecimalSetting(value: $0, units: basalRateUnits) }
     let maxBolusValues = stride(from: 0.0, through: 30.0, by: 1.0).map { DecimalSetting(value: $0, units: insulinUnits) }
     let glucoseTargetValues = stride(from: 80.0, through: 140.0, by: 5.0).map { DecimalSetting(value: $0, units: glucoseUnits) }
-    let glucoseSafetyShutoffValues = stride(from: 70.0, through: 130.0, by: 5.0).map { DecimalSetting(value: $0, units: glucoseUnits) }
+    let glucoseShutoffThresholdValues = stride(from: 70.0, through: 130.0, by: 5.0).map { DecimalSetting(value: $0, units: glucoseUnits) }
     let microBolusDoseFactorValues = stride(from: 0.25, through: 0.5, by: 0.05).map { DecimalSetting(value: $0, units: gainUnits) }
     let bolusValues = stride(from: 0.5, through: 20.0, by: 0.5).map { DecimalSetting(value: $0, units: insulinUnits) }
     let pidIntegratorValues = stride(from: 0.0, through: 0.085, by: 0.005).map {
@@ -82,7 +82,7 @@ public class SettingsViewModel: ObservableObject {
     @Published var insulinSensitivity: DecimalSetting
     @Published var maxBasalRate: DecimalSetting
     @Published var maxBolus: DecimalSetting
-    @Published var glucoseSafetyShutoff: DecimalSetting
+    @Published var glucoseShutoffThreshold: DecimalSetting
     @Published var glucoseTarget: DecimalSetting
     @Published var bolusAmountForLess: DecimalSetting
     @Published var bolusAmountForUsual: DecimalSetting
@@ -147,7 +147,7 @@ public class SettingsViewModel: ObservableObject {
         mlBasalSchedule = DecimalSettingSchedule(settings.learnedBasalRatesUnitsPerHour, units: SettingsViewModel.basalRateUnits)
         mlInsulinSensitivitySchedule = DecimalSettingSchedule(settings.learnedInsulinSensitivityInMgDlPerUnit, units: SettingsViewModel.insulinSensitivityUnits)
         maxBolus = DecimalSetting(value: settings.maxBolusUnits, units: SettingsViewModel.insulinUnits)
-        glucoseSafetyShutoff = DecimalSetting(value: settings.shutOffGlucoseInMgDl, units: SettingsViewModel.glucoseUnits)
+        glucoseShutoffThreshold = DecimalSetting(value: settings.shutOffGlucoseInMgDl, units: SettingsViewModel.glucoseUnits)
         glucoseTarget = DecimalSetting(value: settings.targetGlucoseInMgDl, units: SettingsViewModel.glucoseUnits)
         bolusAmountForLess = DecimalSetting(value: settings.getBolusAmountForLess(), units: SettingsViewModel.insulinUnits)
         bolusAmountForUsual = DecimalSetting(value: settings.getBolusAmountForUsual(), units: SettingsViewModel.insulinUnits)
@@ -175,7 +175,7 @@ public class SettingsViewModel: ObservableObject {
         mlBasalSchedule = DecimalSettingSchedule(settings.learnedBasalRatesUnitsPerHour, units: SettingsViewModel.basalRateUnits)
         mlInsulinSensitivitySchedule = DecimalSettingSchedule(settings.learnedInsulinSensitivityInMgDlPerUnit, units: SettingsViewModel.insulinSensitivityUnits)
         maxBolus = DecimalSetting(value: settings.maxBolusUnits, units: SettingsViewModel.insulinUnits)
-        glucoseSafetyShutoff = DecimalSetting(value: settings.shutOffGlucoseInMgDl, units: SettingsViewModel.glucoseUnits)
+        glucoseShutoffThreshold = DecimalSetting(value: settings.shutOffGlucoseInMgDl, units: SettingsViewModel.glucoseUnits)
         glucoseTarget = DecimalSetting(value: settings.targetGlucoseInMgDl, units: SettingsViewModel.glucoseUnits)
         bolusAmountForLess = DecimalSetting(value: settings.getBolusAmountForLess(), units: SettingsViewModel.insulinUnits)
         bolusAmountForUsual = DecimalSetting(value: settings.getBolusAmountForUsual(), units: SettingsViewModel.insulinUnits)
@@ -189,7 +189,7 @@ public class SettingsViewModel: ObservableObject {
     func snapshot() -> CodableSettings {
         let learnedBasalRate = LearnedSettingsSchedule.from(schedule: mlBasalSchedule)
         let learnedInsulinSensitivity = LearnedSettingsSchedule.from(schedule: mlInsulinSensitivitySchedule)
-        return CodableSettings(created: Date(), pumpBasalRateUnitsPerHour: pumpBasalRate.value, insulinSensitivityInMgDlPerUnit: insulinSensitivity.value, maxBasalRateUnitsPerHour: maxBasalRate.value, maxBolusUnits: maxBolus.value, shutOffGlucoseInMgDl: glucoseSafetyShutoff.value, targetGlucoseInMgDl: glucoseTarget.value, closedLoopEnabled: closedLoopEnabled, useMachineLearningClosedLoop: useMachineLearningClosedLoop, useMicroBolus: useMicroBolus, microBolusDoseFactor: microBolusDoseFactor.value, learnedBasalRateUnitsPerHour: learnedBasalRate, learnedInsulinSensitivityInMgDlPerUnit: learnedInsulinSensitivity, bolusAmountForLess: bolusAmountForLess.value, bolusAmountForUsual: bolusAmountForUsual.value, bolusAmountForMore: bolusAmountForMore.value, pidIntegratorGain: pidIntegratorGain.value, pidDerivativeGain: pidDerivativeGain.value, useBiologicalInvariant: useBiologicalInvariant, machineLearningGain: machineLearningGain.value)
+        return CodableSettings(created: Date(), pumpBasalRateUnitsPerHour: pumpBasalRate.value, insulinSensitivityInMgDlPerUnit: insulinSensitivity.value, maxBasalRateUnitsPerHour: maxBasalRate.value, maxBolusUnits: maxBolus.value, shutOffGlucoseInMgDl: glucoseShutoffThreshold.value, targetGlucoseInMgDl: glucoseTarget.value, closedLoopEnabled: closedLoopEnabled, useMachineLearningClosedLoop: useMachineLearningClosedLoop, useMicroBolus: useMicroBolus, microBolusDoseFactor: microBolusDoseFactor.value, learnedBasalRateUnitsPerHour: learnedBasalRate, learnedInsulinSensitivityInMgDlPerUnit: learnedInsulinSensitivity, bolusAmountForLess: bolusAmountForLess.value, bolusAmountForUsual: bolusAmountForUsual.value, bolusAmountForMore: bolusAmountForMore.value, pidIntegratorGain: pidIntegratorGain.value, pidDerivativeGain: pidDerivativeGain.value, useBiologicalInvariant: useBiologicalInvariant, machineLearningGain: machineLearningGain.value)
     }
 }
 

--- a/ios/BioKernel/BioKernel/Views/SettingsView.swift
+++ b/ios/BioKernel/BioKernel/Views/SettingsView.swift
@@ -57,7 +57,7 @@ struct SettingsView: View {
                 Section("Guardrails") {
                     DecimalPicker(title: "Max basal rate", selection: $settingsViewModel.maxBasalRate, items: settingsViewModel.maxBasalRateValues, hasModifications: $hasModifications)
                     DecimalPicker(title: "Max bolus", selection: $settingsViewModel.maxBolus, items: settingsViewModel.maxBolusValues, hasModifications: $hasModifications)
-                    DecimalPicker(title: "Glucose safety limit", selection: $settingsViewModel.glucoseSafetyShutoff, items: settingsViewModel.glucoseSafetyShutoffValues, hasModifications: $hasModifications)
+                    DecimalPicker(title: "Suspend insulin below", selection: $settingsViewModel.glucoseShutoffThreshold, items: settingsViewModel.glucoseShutoffThresholdValues, hasModifications: $hasModifications)
                 }
                 
                 Section("Algorithm settings (advanced)") {

--- a/ios/BioKernel/BioKernelTests/SafetyServiceTests.swift
+++ b/ios/BioKernel/BioKernelTests/SafetyServiceTests.swift
@@ -97,7 +97,7 @@ struct SafetyServiceTests {
         // our first dose that will run for 30 minutes
         await safetyService.record(at: startDate, decision: .tempBasal(unitsPerHour: 3.0), candidates: candidates, duration: 30.minutesToSeconds())
 
-        let firstTempBasal = await safetyService.tempBasal(at: startDate + 30.minutesToSeconds(), settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
+        let firstTempBasal = await safetyService.tempBasal(at: startDate + 30.minutesToSeconds(), settings: settings.snapshot(), reactiveSafeTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
 
         #expect(abs(firstTempBasal.tempBasal - 3.0) <= insulinAccuracy)
 
@@ -105,7 +105,7 @@ struct SafetyServiceTests {
 
         // at this point we have already delivered 2 units from ML, which is
         // our cap so the system should fall back to the safety tempBasal
-        let secondTempBasal = await safetyService.tempBasal(at: startDate + 60.minutesToSeconds(), settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
+        let secondTempBasal = await safetyService.tempBasal(at: startDate + 60.minutesToSeconds(), settings: settings.snapshot(), reactiveSafeTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
 
         #expect(abs(secondTempBasal.tempBasal - 1.0) <= insulinAccuracy)
     }
@@ -125,7 +125,7 @@ struct SafetyServiceTests {
         // add a micro bolus after 5 minutes
         await safetyService.record(at: startDate + 5.minutesToSeconds(), decision: .microBolus(units: 2.9), candidates: bolusCandidates, duration: 30.minutesToSeconds())
 
-        let secondTempBasal = await safetyService.tempBasal(at: startDate + 60.minutesToSeconds(), settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
+        let secondTempBasal = await safetyService.tempBasal(at: startDate + 60.minutesToSeconds(), settings: settings.snapshot(), reactiveSafeTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
 
         #expect(abs(secondTempBasal.tempBasal - 1.0) <= insulinAccuracy)
     }
@@ -179,7 +179,7 @@ struct SafetyServiceTests {
         await settings.update(pumpBasalRateUnitsPerHour: 2.0 / 3)
         let startDate = Date.f("2018-07-15 03:34:29 +0000")
 
-        let firstTempBasal = await safetyService.tempBasal(at: startDate, settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 4.0, machineLearningTempBasalUnitsPerHour: 0.0, duration: 30.minutesToSeconds())
+        let firstTempBasal = await safetyService.tempBasal(at: startDate, settings: settings.snapshot(), reactiveSafeTempBasalUnitsPerHour: 4.0, machineLearningTempBasalUnitsPerHour: 0.0, duration: 30.minutesToSeconds())
 
         #expect(abs(firstTempBasal.tempBasal - 0.0) <= insulinAccuracy)
 
@@ -189,7 +189,7 @@ struct SafetyServiceTests {
 
         // at this point we have a deficit of 2 units from ML, which is
         // our cap so the system should fall back to the safety tempBasal
-        let secondTempBasal = await safetyService.tempBasal(at: startDate + 30.minutesToSeconds(), settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 4.0, machineLearningTempBasalUnitsPerHour: 0.0, duration: 30.minutesToSeconds())
+        let secondTempBasal = await safetyService.tempBasal(at: startDate + 30.minutesToSeconds(), settings: settings.snapshot(), reactiveSafeTempBasalUnitsPerHour: 4.0, machineLearningTempBasalUnitsPerHour: 0.0, duration: 30.minutesToSeconds())
 
         #expect(abs(secondTempBasal.tempBasal - 4.0) <= insulinAccuracy)
     }
@@ -212,7 +212,7 @@ struct SafetyServiceTests {
 
         // With historicalMlInsulin=0, requesting ml=3.0 vs safety=1.0 over 30 min
         // (delta = 1.0 U) sits well inside the 2.0 U / 3-hour budget — should pass through unchanged.
-        let result = await safetyService.tempBasal(at: startDate + 5.minutesToSeconds(), settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
+        let result = await safetyService.tempBasal(at: startDate + 5.minutesToSeconds(), settings: settings.snapshot(), reactiveSafeTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
 
         #expect(abs(result.tempBasal - 3.0) <= insulinAccuracy)
     }
@@ -234,7 +234,7 @@ struct SafetyServiceTests {
 
         // ML wants 3.0, safety wants 1.0. Budget exhausted, so the upper clamp
         // forces deltaUnits → 0 and the result lands at safety.
-        let result = await safetyService.tempBasal(at: startDate + 10.minutesToSeconds(), settings: settings.snapshot(), safetyTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
+        let result = await safetyService.tempBasal(at: startDate + 10.minutesToSeconds(), settings: settings.snapshot(), reactiveSafeTempBasalUnitsPerHour: 1.0, machineLearningTempBasalUnitsPerHour: 3.0, duration: 30.minutesToSeconds())
 
         #expect(abs(result.tempBasal - 1.0) <= insulinAccuracy)
     }

--- a/ios/BioKernel/BioKernelTests/Utils/MockClasses.swift
+++ b/ios/BioKernel/BioKernelTests/Utils/MockClasses.swift
@@ -122,7 +122,7 @@ class MockMachineLearning: MachineLearning {
 
 
 class MockSafetyService: SafetyService {
-    func tempBasal(at: Date, settings: CodableSettings, safetyTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval) async -> BioKernel.SafetyTempBasal {
+    func tempBasal(at: Date, settings: CodableSettings, reactiveSafeTempBasalUnitsPerHour: Double, machineLearningTempBasalUnitsPerHour: Double, duration: TimeInterval) async -> BioKernel.SafetyTempBasal {
         return SafetyTempBasal(tempBasal: 0, machineLearningInsulinLastThreeHours: 0)
     }
 


### PR DESCRIPTION
We were overloading the phrase Safety a bit in the GlucOS
implemenation. This PR simply renames some of the variables and
argument labels to be more specific and use the terminology
established in our academic paper.

Note: We did NOT change persisted settings property names to avoid a
migration and the settings property names were ok.
