### PR TITLE
Update AI Dosing

### DIFF
--- a/ios/BioKernel/BioKernel/DependencyInjection/AppComposition.swift
+++ b/ios/BioKernel/BioKernel/DependencyInjection/AppComposition.swift
@@ -76,7 +76,6 @@ final class AppComposition {
         let observableState = AppObservableState()
         let healthKitStorage = LocalHealthKitStorage(storedObjectFactory: storedObjectFactory)
         let targetGlucoseService = LocalTargetGlucoseService()
-        let machineLearning = AIDosing()
         let pushNotificationService = LocalPushNotificationService()
 
         // Tier 1 — only Tier 0 deps
@@ -99,6 +98,7 @@ final class AppComposition {
             watchComms: { watchCommsBox.resolve() },
             settingsStorage: { settingsStorage }
         )
+        let machineLearning = AIDosing(insulinStorage: insulinStorage)
 
         // Tier 2 — physiology depends on storages
         let physiologicalModels = LocalPhysiologicalModels(

--- a/ios/BioKernel/BioKernel/Services/MachineLearning.swift
+++ b/ios/BioKernel/BioKernel/Services/MachineLearning.swift
@@ -45,46 +45,79 @@ struct MLUtilities {
 }
 
 actor AIDosing: MachineLearning {
+    private let insulinStorage: InsulinStorage
+
+    init(insulinStorage: InsulinStorage) {
+        self.insulinStorage = insulinStorage
+    }
+
     private func log(_ str: String) async {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ssZZZZZ"
         let at = dateFormatter.string(from: Date())
-        
+
         let logString = "\(at): AI temp basal: \(str)"
         print(logString)
     }
 
-    // This version of the algorithm is specifically to dose more insulin
+    /// Proportional controller with dynamicISF, decoupled from the reactive safe (PID) model.
+    /// Computes the correction insulin needed to bring glucose to target using an
+    /// aggressiveness-adjusted ISF, then nets it against actual IOB relative to the
+    /// baseline IOB we'd expect from continuous basal delivery.
+    ///
+    /// Intent: dose more aggressively above target. Returns nil when at/below target so the
+    /// pipeline falls back to the physiological tempBasal.
     func tempBasal(settings: CodableSettings, glucoseInMgDl: Double, targetGlucoseInMgDl: Double, insulinOnBoard: Double, dataFrame: [AddedGlucoseDataRow]?, at: Date, pidTempBasal: PIDTempBasalResult) async -> Double? {
-        
+
         await log("start")
         let dataFrame = dataFrame ?? []
-        
+
         // since this model is just about dosing more, if we have been low at
         // all in the past two hours just bail
         let min = dataFrame.map({ $0.glucose }).min() ?? 75
         guard min >= 70 else { await log("low in dataFrame, bail"); return nil }
 
-        return glucosDynamicISF(glucose: glucoseInMgDl, targetGlucose: targetGlucoseInMgDl, pidTempBasal: pidTempBasal)
-    }
-
-    /// Simplified version of dynamicISF from Trio. Since dynamicISF isn't based on anything
-    /// physiological -- it's just math to dose more when you're high -- let's keep the math super simple.
-    ///
-    /// Conceptually what this is trying to do is get the individual back into a more manageable range
-    /// so that the more principled adaptations can take over.
-    func glucosDynamicISF(glucose: Double, targetGlucose: Double, pidTempBasal: PIDTempBasalResult) -> Double? {
-
-        // increase dose by up to 50%
+        // ML is intended to dose more aggressively above target; defer to phys otherwise
+        guard glucoseInMgDl > targetGlucoseInMgDl else { return nil }
+        // if glucose is dropping already, we can bail from ML dosing
+        guard let derivative = pidTempBasal.derivative, derivative >= 0 else {
+            return nil
+        }
+        
+        // dynamicISF: lower ISF (more aggressive) linearly with glucose excess above target,
+        // capped at a 50% increase in dosing.
         let maxInsulinScalingIncrease = 0.5
         let glucoseRangeForScaling = 150.0
+        let rawScaling = 1 + maxInsulinScalingIncrease * (glucoseInMgDl - targetGlucoseInMgDl) / glucoseRangeForScaling
+        let scalingFactor = rawScaling.clamp(low: 1, high: 1 + maxInsulinScalingIncrease)
+        let insulinSensitivity = settings.learnedInsulinSensitivity(at: at)
+        guard insulinSensitivity > 0 else { return nil }
+        let mlInsulinSensitivity = insulinSensitivity / scalingFactor
+
+        // baseline IOB we'd expect from continuous basal delivery
+        let basalRate = settings.learnedBasalRate(at: at)
+        let insulinType = await insulinStorage.currentInsulinType()
+        let basalBaselineIoB = PhysiologicalUtilities.calculateBasalBaselineInsulinOnBoard(basalRate: basalRate, insulinType: insulinType)
+
+        // P-controller in glucose units, converted to insulin via the adjusted ISF,
+        // then netted against the IOB excess over baseline.
+        let correctionInsulin = (glucoseInMgDl - targetGlucoseInMgDl) / mlInsulinSensitivity
+        let mlDose = basalBaselineIoB + correctionInsulin - insulinOnBoard
+
+        // if mlDose is 0 or negative, we can just use the reactive safe
+        // controller value
+        guard mlDose > 0 else {
+            await log("ISF_ml: Negative mlDose \(mlDose), fall back to the reactive safe controller")
+            return nil
+        }
         
-        // This conceptually lowers insulin sensitivity for glucose values between
-        // targetGlucose -> targetGlucose + 150 linearly to dose more
-        // insulin while above target
-        guard glucose > targetGlucose else { return nil }
-        let scalingFactor = 1 + maxInsulinScalingIncrease * (glucose - targetGlucose) / glucoseRangeForScaling
-        return pidTempBasal.tempBasal * scalingFactor.clamp(low: 1, high: 1 + maxInsulinScalingIncrease)
+        // convert correction insulin to a tempBasal rate over the correction window
+        let correctionDuration = settings.correctionDurationInSeconds
+        guard correctionDuration > 0 else { return nil }
+        let tempBasal = max(0, mlDose * 1.hoursToSeconds() / correctionDuration + basalRate)
+
+        await log("ISF_ml: \(mlInsulinSensitivity) baseIoB: \(basalBaselineIoB) IoB: \(insulinOnBoard) correction: \(correctionInsulin) mlDose: \(mlDose) tempBasal: \(tempBasal)")
+        return tempBasal
     }
 }
 

--- a/ios/BioKernel/BioKernel/Services/MachineLearning.swift
+++ b/ios/BioKernel/BioKernel/Services/MachineLearning.swift
@@ -80,7 +80,7 @@ actor AIDosing: MachineLearning {
         // ML is intended to dose more aggressively above target; defer to phys otherwise
         guard glucoseInMgDl > targetGlucoseInMgDl else { return nil }
         // if glucose is dropping already, we can bail from ML dosing
-        guard let derivative = pidTempBasal.derivative, derivative >= 0 else {
+        guard let derivative = pidTempBasal.derivative, derivative > 0 else {
             return nil
         }
         
@@ -114,7 +114,7 @@ actor AIDosing: MachineLearning {
         // convert correction insulin to a tempBasal rate over the correction window
         let correctionDuration = settings.correctionDurationInSeconds
         guard correctionDuration > 0 else { return nil }
-        let tempBasal = max(0, mlDose * 1.hoursToSeconds() / correctionDuration + basalRate)
+        let tempBasal = (mlDose * 1.hoursToSeconds() / correctionDuration + basalRate).clamp(low: 0, high: settings.maxBasalRate())
 
         await log("ISF_ml: \(mlInsulinSensitivity) baseIoB: \(basalBaselineIoB) IoB: \(insulinOnBoard) correction: \(correctionInsulin) mlDose: \(mlDose) tempBasal: \(tempBasal)")
         return tempBasal

--- a/ios/BioKernel/BioKernel/Services/MachineLearning.swift
+++ b/ios/BioKernel/BioKernel/Services/MachineLearning.swift
@@ -46,14 +46,14 @@ struct MLUtilities {
 
 actor AIDosing: MachineLearning {
     private let insulinStorage: InsulinStorage
-
+    private let dateFormatter = DateFormatter()
+    
     init(insulinStorage: InsulinStorage) {
         self.insulinStorage = insulinStorage
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ssZZZZZ"
     }
 
     private func log(_ str: String) async {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ssZZZZZ"
         let at = dateFormatter.string(from: Date())
 
         let logString = "\(at): AI temp basal: \(str)"

--- a/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
+++ b/ios/BioKernel/BioKernel/Services/PhysiologicalModels.swift
@@ -63,10 +63,12 @@ struct PIDState: Codable {
 
 struct PhysiologicalUtilities {
     static func calculateBasalBaselineInsulinOnBoard(basalRate: Double, insulinType: InsulinType) -> Double {
-        let now = Date()
         // we use basalBaselineInsulinOnBoard to figure out how much iob we should have in steady state
-        // when we're operating at our basal rate
-        return DoseEntry(type: .basal, startDate: now - 6.hoursToSeconds(), endDate: now, value: basalRate, unit: .unitsPerHour, insulinType: insulinType, isMutable: false).insulinOnBoard(at: now)
+        // when we're operating at our basal rate. The insulin model is time-translation invariant
+        // (depends only on elapsed time since each dose), so we use a fixed anchor to keep this pure.
+        let endDate = Date(timeIntervalSinceReferenceDate: 0)
+        let startDate = endDate - 6.hoursToSeconds()
+        return DoseEntry(type: .basal, startDate: startDate, endDate: endDate, value: basalRate, unit: .unitsPerHour, insulinType: insulinType, isMutable: false).insulinOnBoard(at: endDate)
     }
 }
 


### PR DESCRIPTION
In our previous implementation we tied our AI dosing directly to the
results of the reactive safe controller. With our new implementation,
we decouple the two since the reactive safe controller has a feedback
loop with previous ML dosing via the increased IOB. The net effect
should be more aggressive AI dosing.

Note: For AI dosing we don't need to be that rigorous since it's all
run through our safety service
