### PR TITLE
Settings UI refactor

### DIFF
--- a/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
+++ b/ios/BioKernel/BioKernel.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		3B4052302B6DA87A004D232D /* AddedGlucoseModel.mlpackage in Sources */ = {isa = PBXBuildFile; fileRef = 3B40522F2B6DA87A004D232D /* AddedGlucoseModel.mlpackage */; };
 		3B40DE672D243C6C0032328F /* MicroBolusAmountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B40DE662D243C6C0032328F /* MicroBolusAmountTest.swift */; };
 		3B40DE692D24453F0032328F /* LoopFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B40DE682D24453F0032328F /* LoopFunctionTests.swift */; };
+		3B4740632FA7B0BE00352C3E /* DataExportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4740622FA7B0BE00352C3E /* DataExportView.swift */; };
+		3B4740652FA7B0CD00352C3E /* SettingsHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4740642FA7B0CD00352C3E /* SettingsHomeView.swift */; };
 		3B4CFE1C2C223B8900BDB1CB /* CGMBLEKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B4CFE132C2230D800BDB1CB /* CGMBLEKit.framework */; };
 		3B4CFE1D2C223B8900BDB1CB /* CGMBLEKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B4CFE132C2230D800BDB1CB /* CGMBLEKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3B4CFE1E2C223B9300BDB1CB /* CGMBLEKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B4CFE162C2230DF00BDB1CB /* CGMBLEKitUI.framework */; };
@@ -243,6 +245,8 @@
 		3B40522F2B6DA87A004D232D /* AddedGlucoseModel.mlpackage */ = {isa = PBXFileReference; lastKnownFileType = folder.mlpackage; path = AddedGlucoseModel.mlpackage; sourceTree = "<group>"; };
 		3B40DE662D243C6C0032328F /* MicroBolusAmountTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroBolusAmountTest.swift; sourceTree = "<group>"; };
 		3B40DE682D24453F0032328F /* LoopFunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopFunctionTests.swift; sourceTree = "<group>"; };
+		3B4740622FA7B0BE00352C3E /* DataExportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExportView.swift; sourceTree = "<group>"; };
+		3B4740642FA7B0CD00352C3E /* SettingsHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHomeView.swift; sourceTree = "<group>"; };
 		3B4CFE132C2230D800BDB1CB /* CGMBLEKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CGMBLEKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4CFE162C2230DF00BDB1CB /* CGMBLEKitUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CGMBLEKitUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B5076382F92F77400E5D3A6 /* PushNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationService.swift; sourceTree = "<group>"; };
@@ -590,6 +594,7 @@
 				3B36F67C2B311C0800008F4A /* AppColors.swift */,
 				3B7F08612B31590D002930A4 /* BolusProgressView.swift */,
 				3BBC7C7C2B15679700410123 /* BolusView.swift */,
+				3B4740622FA7B0BE00352C3E /* DataExportView.swift */,
 				3B6063B12B54BDB7009D9CBC /* DecimalPicker.swift */,
 				3B8906542E50EA9500F32799 /* DiagnosticChartScrollView.swift */,
 				3BF1F1E32E4F1D3D00AF36AD /* DiagnosticDataView.swift */,
@@ -606,6 +611,7 @@
 				3B36F67A2B311BCE00008F4A /* NavigationModifier.swift */,
 				3BF1F1E72E4F1D3D00AF36AD /* PIDView.swift */,
 				3BAD0C4B2E521ECA00B1F8CF /* PumpHistoryView.swift */,
+				3B4740642FA7B0CD00352C3E /* SettingsHomeView.swift */,
 				3B6063B32B54BDFA009D9CBC /* SettingsView.swift */,
 			);
 			path = Views;
@@ -861,10 +867,12 @@
 				3C4911F12AF4D0630070D3B4 /* ManagerExtensions.swift in Sources */,
 				3B0044762F956C7B0051AFA7 /* AppObservableState.swift in Sources */,
 				3B5076392F92F77400E5D3A6 /* PushNotificationService.swift in Sources */,
+				3B4740652FA7B0CD00352C3E /* SettingsHomeView.swift in Sources */,
 				3C4911F32AF4D77E0070D3B4 /* Colors.swift in Sources */,
 				3BD3FFA92F9C311B0056F151 /* HealthKitSettingsView.swift in Sources */,
 				3B0044802F956D0000000001 /* AppComposition.swift in Sources */,
 				3B0044822F956D0000000003 /* AppContextNotifier.swift in Sources */,
+				3B4740632FA7B0BE00352C3E /* DataExportView.swift in Sources */,
 				3BA00A552D23157C0002B051 /* SettingsDataTypes.swift in Sources */,
 				3BF1F1E22E4F1A4100AF36AD /* ClosedLoopChartData.swift in Sources */,
 				3C4F79442AFB17D500786EB5 /* InsulinStorage.swift in Sources */,

--- a/ios/BioKernel/BioKernel/Views/DataExportView.swift
+++ b/ios/BioKernel/BioKernel/Views/DataExportView.swift
@@ -1,0 +1,40 @@
+//
+//  DataExportView.swift
+//  BioKernel
+//
+
+import SwiftUI
+
+struct DataExportView: View {
+    var body: some View {
+        Form {
+            Section {
+                if let url = closedLoopResultsURL() {
+                    ShareLink(item: url) {
+                        Label("Share closed loop data", systemImage: "square.and.arrow.up")
+                    }
+                } else {
+                    Text("No closed loop data yet")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .modifier(NavigationModifier())
+        .navigationTitle("Data export")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func closedLoopResultsURL() -> URL? {
+        guard let documents = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false) else {
+            return nil
+        }
+        let url = documents.appendingPathComponent("closed_loop_results.json")
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DataExportView()
+    }
+}

--- a/ios/BioKernel/BioKernel/Views/MainView.swift
+++ b/ios/BioKernel/BioKernel/Views/MainView.swift
@@ -17,7 +17,7 @@ struct MainView: View {
     @EnvironmentObject var appState: AppObservableState
     @EnvironmentObject var glucoseAlertsViewModel: GlucoseAlertsViewModel
     @Environment(\.composition) var composition: AppComposition?
-    @State var navigateToSettings = false
+    @State var navigateToSettingsHome = false
     @State var navigateToAddCgm = false
     @State var navigateToCgmSettings = false
     @State var navigateToAddPump = false
@@ -25,7 +25,6 @@ struct MainView: View {
     @State var navigateToBolus = false
     @State var navigateToSettingsFromUrl = false
     @State var navigateToGlucoseAlerts = false
-    @State var navigateToHealthKitSettings = false
     @State var settingsFromUrl: CodableSettings? = nil
     @State var selectedHours = 4
     @State var showChartSettingsSheet = false
@@ -115,17 +114,8 @@ struct MainView: View {
                                 Image(systemName: "bell.slash.fill").tint(.white)
                             }
                         }
-                        Menu {
-                            Button {
-                                navigateToSettings = true
-                            } label: {
-                                Label("Therapy settings", systemImage: "slider.horizontal.3")
-                            }
-                            Button {
-                                navigateToHealthKitSettings = true
-                            } label: {
-                                Label("HealthKit", systemImage: "heart.fill")
-                            }
+                        Button {
+                            navigateToSettingsHome = true
                         } label: {
                             Image(systemName: "gearshape.fill")
                                 .tint(.white)
@@ -133,11 +123,8 @@ struct MainView: View {
                     }
                 }
             }
-            .navigationDestination(isPresented: $navigateToSettings) {
-                if let composition {
-                    SettingsView(settingsFromUrl: nil, settingsViewModel: makeSettingsViewModel(composition: composition))
-                        .modifier(NavigationModifier())
-                }
+            .navigationDestination(isPresented: $navigateToSettingsHome) {
+                SettingsHomeView()
             }
             .navigationDestination(isPresented: $navigateToSettingsFromUrl) {
                 if let composition {
@@ -170,9 +157,6 @@ struct MainView: View {
             }
             .navigationDestination(isPresented: $navigateToGlucoseAlerts) {
                 GlucoseAlertsView()
-            }
-            .navigationDestination(isPresented: $navigateToHealthKitSettings) {
-                HealthKitSettingsView()
             }
             .sheet(isPresented: $showChartSettingsSheet) {
                 if let composition {

--- a/ios/BioKernel/BioKernel/Views/SettingsHomeView.swift
+++ b/ios/BioKernel/BioKernel/Views/SettingsHomeView.swift
@@ -1,0 +1,53 @@
+//
+//  SettingsHomeView.swift
+//  BioKernel
+//
+
+import SwiftUI
+
+struct SettingsHomeView: View {
+    @Environment(\.composition) var composition: AppComposition?
+
+    var body: some View {
+        Form {
+            Section {
+                NavigationLink {
+                    if let composition {
+                        SettingsView(
+                            settingsFromUrl: nil,
+                            settingsViewModel: SettingsViewModel(
+                                settings: composition.settingsStorage.snapshot(),
+                                settingsStorage: composition.settingsStorage,
+                                deviceDataManager: composition.deviceDataManager
+                            )
+                        )
+                        .modifier(NavigationModifier())
+                    }
+                } label: {
+                    Label("Therapy settings", systemImage: "slider.horizontal.3")
+                }
+
+                NavigationLink {
+                    HealthKitSettingsView()
+                } label: {
+                    Label("HealthKit", systemImage: "heart.fill")
+                }
+
+                NavigationLink {
+                    DataExportView()
+                } label: {
+                    Label("Data export", systemImage: "square.and.arrow.up")
+                }
+            }
+        }
+        .modifier(NavigationModifier())
+        .navigationTitle("Settings")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SettingsHomeView()
+    }
+}

--- a/ios/BioKernel/BioKernel/Views/SettingsView.swift
+++ b/ios/BioKernel/BioKernel/Views/SettingsView.swift
@@ -81,17 +81,6 @@ struct SettingsView: View {
                     DecimalPicker(title: "Usual", selection: $settingsViewModel.bolusAmountForUsual, items: settingsViewModel.bolusValues, hasModifications: $hasModifications)
                     DecimalPicker(title: "Less", selection: $settingsViewModel.bolusAmountForLess, items: settingsViewModel.bolusValues, hasModifications: $hasModifications)
                 }
-
-                Section {
-                    if let url = closedLoopResultsURL() {
-                        ShareLink(item: url) {
-                            Label("Share closed loop data", systemImage: "square.and.arrow.up")
-                        }
-                    } else {
-                        Text("No closed loop data yet")
-                            .foregroundStyle(.secondary)
-                    }
-                }
             }
         }
         .modifier(NavigationModifier())
@@ -128,14 +117,6 @@ struct SettingsView: View {
             settingsViewModel.update(using: settingsFromUrl)
             hasModifications = true
         }
-    }
-
-    private func closedLoopResultsURL() -> URL? {
-        guard let documents = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false) else {
-            return nil
-        }
-        let url = documents.appendingPathComponent("closed_loop_results.json")
-        return FileManager.default.fileExists(atPath: url.path) ? url : nil
     }
 }
 


### PR DESCRIPTION
This commit adds an explicit navigation view when users click on the
settings button and provides an additional option: data export. With
this new data export view, we can move the "share closed loop data"
out of therapy settings and into its own view.
