### PR TITLE
Remove incorrect clamp

### DIFF
--- a/ios/BioKernel/BioKernel/Services/MachineLearning.swift
+++ b/ios/BioKernel/BioKernel/Services/MachineLearning.swift
@@ -72,7 +72,7 @@ actor AIDosing: MachineLearning {
         guard let tempBasal = glucosDynamicISF(glucose: glucoseInMgDl, targetGlucose: targetGlucoseInMgDl, pidTempBasal: pidTempBasal) else {
             return nil
         }
-        return tempBasal.clamp(low: 0, high: settings.maxBasalRate())
+        return tempBasal
     }
 
     /// Simplified version of dynamicISF from Trio. Since dynamicISF isn't based on anything


### PR DESCRIPTION
For the AIDosing code, it is using a clamp with the wrong max value. I
removed the clamp because there is other layers in the system that
should reason about thresholds and safety parameters.
