### PR TITLE
Create pump and cgm managers on click instead of render

### DIFF
--- a/ios/BioKernel/BioKernel/Views/AddCGMView.swift
+++ b/ios/BioKernel/BioKernel/Views/AddCGMView.swift
@@ -10,17 +10,29 @@ import SwiftUI
 import LoopKit
 import LoopKitUI
 
+
+private struct CgmSetup: Identifiable {
+    let identifier: String
+    let result: Swift.Result<SetupUIResult<CGMManagerViewController, CGMManagerUI>, Error>
+
+    var id: String { identifier }
+}
+
 struct AddCGMView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.composition) var composition: AppComposition?
-    @State var descriptor: CGMManagerDescriptor?
+    @State private var cgmSetup: CgmSetup?
 
     var body: some View {
         let cgmDescriptors = composition?.deviceDataManager.cgmManagerDescriptors() ?? []
         List {
             ForEach(cgmDescriptors, id: \.identifier) { cgmDescriptor in
                 Button {
-                    descriptor = cgmDescriptor
+                    guard let composition else { return }
+                    cgmSetup = CgmSetup(
+                        identifier: cgmDescriptor.identifier,
+                        result: composition.deviceDataManager.setupCGMManagerUI(withIdentifier: cgmDescriptor.identifier)
+                    )
                 } label: {
                     Text(cgmDescriptor.localizedTitle)
                 }
@@ -28,19 +40,14 @@ struct AddCGMView: View {
         }
         .modifier(NavigationModifier())
         .navigationTitle("Add CGM")
-        .sheet(item: $descriptor, onDismiss: didDismiss) { detail in
-            if let composition {
-                switch composition.deviceDataManager.setupCGMManagerUI(withIdentifier: detail.identifier) {
-                case .failure(let error):
-                    Text("failed to setup cgm manager: \(String(describing: error))")
-                case .success(let success):
-                    switch success {
-                    case .userInteractionRequired(let setupViewController):
-                        CGMSetupView(setupViewController: setupViewController)
-                    case .createdAndOnboarded(let cgmManagerUI):
-                        CGMManagerView(cgmManagerUI: cgmManagerUI)
-                    }
-                }
+        .sheet(item: $cgmSetup, onDismiss: didDismiss) { setup in
+            switch setup.result {
+            case .failure(let error):
+                Text("failed to setup cgm manager: \(String(describing: error))")
+            case .success(.userInteractionRequired(let setupViewController)):
+                CGMSetupView(setupViewController: setupViewController)
+            case .success(.createdAndOnboarded(let cgmManagerUI)):
+                CGMManagerView(cgmManagerUI: cgmManagerUI)
             }
         }
     }

--- a/ios/BioKernel/BioKernel/Views/AddPumpView.swift
+++ b/ios/BioKernel/BioKernel/Views/AddPumpView.swift
@@ -10,8 +10,16 @@ import SwiftUI
 import LoopKit
 import LoopKitUI
 
+
+private struct PumpSetup: Identifiable {
+    let identifier: String
+    let result: Swift.Result<SetupUIResult<PumpManagerViewController, PumpManagerUI>, Error>
+
+    var id: String { identifier }
+}
+
 struct AddPumpView: View {
-    @State var descriptor: PumpManagerDescriptor?
+    @State private var pumpSetup: PumpSetup?
 
     @Environment(\.dismiss) var dismiss
     @Environment(\.composition) var composition: AppComposition?
@@ -21,7 +29,11 @@ struct AddPumpView: View {
         List {
             ForEach(pumpDescriptors, id: \.identifier) { pumpDescriptor in
                 Button {
-                    descriptor = pumpDescriptor
+                    guard let composition else { return }
+                    pumpSetup = PumpSetup(
+                        identifier: pumpDescriptor.identifier,
+                        result: composition.deviceDataManager.setupPumpManagerUI(withIdentifier: pumpDescriptor.identifier)
+                    )
                 } label: {
                     Text(pumpDescriptor.localizedTitle)
                 }
@@ -29,19 +41,14 @@ struct AddPumpView: View {
         }
         .modifier(NavigationModifier())
         .navigationTitle("Add pump")
-        .sheet(item: $descriptor, onDismiss: didDismiss) { detail in
-            if let composition {
-                switch composition.deviceDataManager.setupPumpManagerUI(withIdentifier: detail.identifier) {
-                case .failure(let error):
-                    Text("failed to setup pump manager: \(String(describing: error))")
-                case .success(let success):
-                    switch success {
-                    case .userInteractionRequired(let setupViewController):
-                        PumpSetupView(setupViewController: setupViewController)
-                    case .createdAndOnboarded(let pumpManagerUI):
-                        PumpManagerView(pumpManagerUI: pumpManagerUI)
-                    }
-                }
+        .sheet(item: $pumpSetup, onDismiss: didDismiss) { setup in
+            switch setup.result {
+            case .failure(let error):
+                Text("failed to setup pump manager: \(String(describing: error))")
+            case .success(.userInteractionRequired(let setupViewController)):
+                PumpSetupView(setupViewController: setupViewController)
+            case .success(.createdAndOnboarded(let pumpManagerUI)):
+                PumpManagerView(pumpManagerUI: pumpManagerUI)
             }
         }
     }


### PR DESCRIPTION
Previously, we would create new CGM and Pump manager instances each
time the view rendered, which could cause problems. This change
creates instances only on presses.
