### PR TITLE
Expose DoseProgress explicity as environment object

### DIFF
--- a/ios/BioKernel/BioKernel/BioKernelApp.swift
+++ b/ios/BioKernel/BioKernel/BioKernelApp.swift
@@ -37,6 +37,7 @@ struct BioKernelApp: App {
                     .toolbarColorScheme(.dark, for: .navigationBar)
                     .environment(\.composition, composition)
                     .environmentObject(composition.observableState)
+                    .environmentObject(composition.doseProgress)
                     .environmentObject(composition.glucoseAlertsService.viewModel())
             }
         }

--- a/ios/BioKernel/BioKernel/DependencyInjection/AppComposition.swift
+++ b/ios/BioKernel/BioKernel/DependencyInjection/AppComposition.swift
@@ -49,6 +49,7 @@ final class AppComposition {
 
     // UI-observable shared state
     let observableState: AppObservableState
+    let doseProgress: DoseProgress
 
     init() {
         // The app may be woken by CGM Bluetooth before first unlock (e.g. after
@@ -74,6 +75,7 @@ final class AppComposition {
         let http = JsonHttp()
         let bluetoothProvider = BluetoothStateManager()
         let observableState = AppObservableState()
+        let doseProgress = DoseProgress()
         let healthKitStorage = LocalHealthKitStorage(storedObjectFactory: storedObjectFactory)
         let targetGlucoseService = LocalTargetGlucoseService()
         let machineLearning = AIDosing()
@@ -134,7 +136,8 @@ final class AppComposition {
             machineLearning: machineLearning,
             safetyService: safetyService,
             settingsStorage: { settingsStorage },
-            observableState: observableState
+            observableState: observableState,
+            doseProgress: doseProgress
         )
         closedLoopBox.set(closedLoopService)
 
@@ -159,6 +162,7 @@ final class AppComposition {
         self.http = http
         self.bluetoothProvider = bluetoothProvider
         self.observableState = observableState
+        self.doseProgress = doseProgress
         self.healthKitStorage = healthKitStorage
         self.targetGlucoseService = targetGlucoseService
         self.machineLearning = machineLearning

--- a/ios/BioKernel/BioKernel/LoopKitSupport/DoseProgress.swift
+++ b/ios/BioKernel/BioKernel/LoopKitSupport/DoseProgress.swift
@@ -9,7 +9,18 @@ import Foundation
 import Combine
 import LoopKit
 
-public class DoseProgress: ObservableObject, DoseProgressObserver {
+/// Bolus-in-progress state, shared between the pump layer and the UI.
+///
+/// Owned by `AppComposition` and injected as its own environment object rather
+/// than living inside `AppObservableState`: a nested `ObservableObject` never
+/// fires the outer object's `objectWillChange`, so views gating on `isComplete`
+/// would not refresh when a bolus starts or finishes.
+///
+/// `@preconcurrency` on the observer conformance bridges LoopKit's nonisolated
+/// callback. Every reporter we register with is created with
+/// `reportingOn: .main`, so the callback really does arrive on the main actor.
+@MainActor
+public class DoseProgress: ObservableObject, @preconcurrency DoseProgressObserver {
     @Published var deliveredUnits: Double = 0.0
     @Published var percentComplete: Double = 0.0
     @Published var totalUnits: Double = 0.0

--- a/ios/BioKernel/BioKernel/LoopKitSupport/ManagerExtensions.swift
+++ b/ios/BioKernel/BioKernel/LoopKitSupport/ManagerExtensions.swift
@@ -98,13 +98,13 @@ extension PumpManager {
         }
     }
     
-    func enactBolus(units: Double, activationType: BolusActivationType, observableState: AppObservableState) async -> PumpManagerError? {
+    func enactBolus(units: Double, activationType: BolusActivationType, doseProgress: DoseProgress) async -> PumpManagerError? {
         return await withCheckedContinuation { continuation in
             self.enactBolus(units: units, activationType: activationType) { error in
                 if error == nil {
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         if let progress = self.createBolusProgressReporter(reportingOn: .main) {
-                            observableState.doseProgress.update(totalUnits: units, doseProgressReporter: progress)
+                            doseProgress.update(totalUnits: units, doseProgressReporter: progress)
                         }
                     }
                 }

--- a/ios/BioKernel/BioKernel/Services/AppObservableState.swift
+++ b/ios/BioKernel/BioKernel/Services/AppObservableState.swift
@@ -25,7 +25,6 @@ public final class AppObservableState: ObservableObject {
     @Published public var activeAlert: LoopKit.Alert? = nil
     @Published public var glucoseChartData: [GlucoseChartPoint] = []
     @Published public var filteredGlucoseChartData: [FilteredGlucose] = []
-    @Published public var doseProgress: DoseProgress = DoseProgress()
 
     public init() { }
 

--- a/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
+++ b/ios/BioKernel/BioKernel/Services/ClosedLoopService.swift
@@ -47,6 +47,7 @@ actor LoopRunner: ClosedLoopService {
     private let safetyService: SafetyService
     private let settingsStorage: () -> SettingsStorage
     private let observableState: AppObservableState
+    private let doseProgress: DoseProgress
     private let pipeline: DosingPipeline
 
     init(
@@ -59,6 +60,7 @@ actor LoopRunner: ClosedLoopService {
         safetyService: SafetyService,
         settingsStorage: @escaping () -> SettingsStorage,
         observableState: AppObservableState,
+        doseProgress: DoseProgress,
         startBackgroundTask: Bool = true
     ) {
         self.storage = storedObjectFactory.create(fileName: "closed_loop_results.json")
@@ -67,6 +69,7 @@ actor LoopRunner: ClosedLoopService {
         self.safetyService = safetyService
         self.settingsStorage = settingsStorage
         self.observableState = observableState
+        self.doseProgress = doseProgress
         self.pipeline = DosingPipeline(
             physiological: physiologicalModels,
             machineLearning: machineLearning,
@@ -185,7 +188,7 @@ actor LoopRunner: ClosedLoopService {
 
         if case .microBolus(let rawUnits) = outputs.decision {
             let units = pumpManager.roundToSupportedBolusVolume(units: rawUnits)
-            if let pumpError = await pumpManager.enactBolus(units: units, activationType: .automatic, observableState: observableState) {
+            if let pumpError = await pumpManager.enactBolus(units: units, activationType: .automatic, doseProgress: doseProgress) {
                 print("Pump error: \(String(describing: pumpError))")
                 return .pumpError(at: at, settings: settings, cgmPumpMetadata: cgmPumpMetadata, snapshot: snapshot)
             }

--- a/ios/BioKernel/BioKernel/Views/BolusProgressView.swift
+++ b/ios/BioKernel/BioKernel/Views/BolusProgressView.swift
@@ -15,11 +15,14 @@ struct BolusProgressView: View {
             Text("Delivered \(String(format: "%0.2f", doseProgress.deliveredUnits)) of \(String(format: "%0.2f", doseProgress.totalUnits)) units")
             Button {
                 composition?.deviceDataManager.pumpManager?.cancelBolus() { result in
-                    switch result {
-                    case .success:
-                        doseProgress.cancel()
-                    case .failure(let error):
-                        doseProgress.error = error.localizedDescription
+                    // LoopKit makes no promise about which queue this lands on
+                    Task { @MainActor in
+                        switch result {
+                        case .success:
+                            doseProgress.cancel()
+                        case .failure(let error):
+                            doseProgress.error = error.localizedDescription
+                        }
                     }
                 }
             } label: {

--- a/ios/BioKernel/BioKernel/Views/BolusView.swift
+++ b/ios/BioKernel/BioKernel/Views/BolusView.swift
@@ -57,7 +57,7 @@ struct BolusView: View {
                     case .some(_):
                         bolusError = "Not authenticated"
                     case .none:
-                        if let error = await pumpManager.enactBolus(units: unitsRounded, activationType: .manualNoRecommendation, observableState: composition.observableState) {
+                        if let error = await pumpManager.enactBolus(units: unitsRounded, activationType: .manualNoRecommendation, doseProgress: composition.doseProgress) {
                             bolusError = error.localizedDescription
                             return
                         } else {

--- a/ios/BioKernel/BioKernel/Views/MainViewAlertView.swift
+++ b/ios/BioKernel/BioKernel/Views/MainViewAlertView.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct MainViewAlertView: View {
-    @EnvironmentObject var appState: AppObservableState
+    @EnvironmentObject var doseProgress: DoseProgress
     @EnvironmentObject var glucoseAlertsViewModel: GlucoseAlertsViewModel
     @Environment(\.composition) var composition: AppComposition?
     var body: some View {
         VStack {
-            if !appState.doseProgress.isComplete {
-                BolusProgressView(doseProgress: appState.doseProgress)
+            if !doseProgress.isComplete {
+                BolusProgressView(doseProgress: doseProgress)
             } else if let alertString = glucoseAlertsViewModel.alertString {
                 MainViewGlucoseAlertView(alertString: alertString)
             } else {
@@ -26,7 +26,7 @@ struct MainViewAlertView: View {
             guard let composition else { return }
             if let pumpManager = composition.deviceDataManager.pumpManager, let bolusProgressReporter = pumpManager.createBolusProgressReporter(reportingOn: DispatchQueue.main) {
                 let totalUnits =  await composition.insulinStorage.activeBolus(at: Date())?.programmedUnits ?? bolusProgressReporter.progress.deliveredUnits / bolusProgressReporter.progress.percentComplete
-                appState.doseProgress.update(totalUnits: totalUnits, doseProgressReporter: bolusProgressReporter)
+                doseProgress.update(totalUnits: totalUnits, doseProgressReporter: bolusProgressReporter)
             }
         }
     }

--- a/ios/BioKernel/BioKernelTests/Utils/ClosedLoopTestSupport.swift
+++ b/ios/BioKernel/BioKernelTests/Utils/ClosedLoopTestSupport.swift
@@ -28,6 +28,7 @@ func makeClosedLoopService(
         safetyService: safetyService,
         settingsStorage: { settings },
         observableState: AppObservableState(),
+        doseProgress: DoseProgress(),
         startBackgroundTask: false
     )
 }


### PR DESCRIPTION
To allow SwiftUI to get updates for the DoseProgress object as a dose
is ongoing, we break out doseProgress on appState and put it in an
environment object. Previously, updates to this object weren't
propagated to the parent appObject.
